### PR TITLE
Adds native status indicator with menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ When it starts without a player, it can stay hidden in the background and show t
 - Updates the UI when player metadata changes
 - Can keep running in the background when no player is available
 - Can show and hide the window automatically as players appear or disappear
-- Can show a status indicator when the desktop supports it
+- Can show a status indicator with show, hide, settings, about, and quit actions when the desktop supports it
 - Provides preferences for compact mode, background notifications, automatic visibility, status indicators, and start on login
 - Hides the window on close; use Quit to stop the app
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ When it starts without a player, it can stay hidden in the background and show t
 - Updates the UI when player metadata changes
 - Can keep running in the background when no player is available
 - Can show and hide the window automatically as players appear or disappear
-- Provides preferences for compact mode, background notifications, automatic visibility, and start on login
+- Can show a status indicator when the desktop supports it
+- Provides preferences for compact mode, background notifications, automatic visibility, status indicators, and start on login
 - Hides the window on close; use Quit to stop the app
 
 ## Build from Source
@@ -99,8 +100,8 @@ sudo ninja -C build uninstall
 Pushing a version tag builds a Flatpak bundle, builds an amd64 Debian package, and creates a GitHub release:
 
 ```bash
-git tag v1.1.1
-git push origin v1.1.1
+git tag v1.2.0
+git push origin v1.2.0
 ```
 
 The release workflow attaches `MPRIS-MiniPlayer-<tag>-x86_64.flatpak` and `mpris-miniplayer_<tag>_amd64.deb` to the generated release.
@@ -127,7 +128,7 @@ v0.2:
 - Run in the background when no MPRIS player is available
 - Show and hide the window automatically when players appear or disappear
 - Show an optional background notification with an Open action
-- Add preferences for notifications, automatic visibility, and start on login
+- Add preferences for notifications, automatic visibility, status indicators, and start on login
 - Hide the window on close and quit only through an explicit Quit action
 
 v0.3:

--- a/data/io.github.ChrisLauinger.MprisMiniPlayer.gschema.xml
+++ b/data/io.github.ChrisLauinger.MprisMiniPlayer.gschema.xml
@@ -21,5 +21,10 @@
       <summary>Use compact mode</summary>
       <description>Whether MPRIS MiniPlayer should use a smaller window layout.</description>
     </key>
+    <key name="show-status-indicator" type="b">
+      <default>true</default>
+      <summary>Show a status indicator</summary>
+      <description>Whether MPRIS MiniPlayer should show a status indicator when the desktop supports StatusNotifierItem indicators.</description>
+    </key>
   </schema>
 </schemalist>

--- a/data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in
+++ b/data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in
@@ -20,6 +20,7 @@
     <release version="1.2.0" date="2026-06-24">
       <description>
         <p>Add an optional native status indicator when the desktop supports StatusNotifierItem.</p>
+        <p>Add a status indicator menu with show, hide, settings, about, and quit actions.</p>
         <p>Add a preference to disable the status indicator and show when the desktop does not support it.</p>
       </description>
     </release>

--- a/data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in
+++ b/data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in
@@ -17,6 +17,12 @@
   </developer>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="1.2.0" date="2026-06-24">
+      <description>
+        <p>Add an optional native status indicator when the desktop supports StatusNotifierItem.</p>
+        <p>Add a preference to disable the status indicator and show when the desktop does not support it.</p>
+      </description>
+    </release>
     <release version="1.1.1" date="2026-06-24">
       <description>
         <p>Reuse the About dialog on repeated activations without constraining it to the mini-player window.</p>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+mpris-miniplayer (1.2.0-1) unstable; urgency=medium
+
+  * Add an optional native status indicator for desktops with
+    StatusNotifierItem support.
+  * Add a preference to disable the status indicator when available.
+  * Keep the status indicator disabled when unsupported or running as Flatpak.
+
+ -- Christian Lauinger <chrislauinger77@users.noreply.github.com>  Wed, 24 Jun 2026 18:43:10 +0200
+
 mpris-miniplayer (1.1.1-1) unstable; urgency=medium
 
   * Reuse the About dialog on repeated activations without constraining it to

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ mpris-miniplayer (1.2.0-1) unstable; urgency=medium
 
   * Add an optional native status indicator for desktops with
     StatusNotifierItem support.
+  * Add a status indicator menu with show, hide, settings, about, and quit
+    actions.
   * Add a preference to disable the status indicator when available.
   * Keep the status indicator disabled when unsupported or running as Flatpak.
 

--- a/debian/mpris-miniplayer.1
+++ b/debian/mpris-miniplayer.1
@@ -1,4 +1,4 @@
-.TH MPRIS-MINIPLAYER 1 "June 2026" "MPRIS MiniPlayer 1.1.1" "User Commands"
+.TH MPRIS-MINIPLAYER 1 "June 2026" "MPRIS MiniPlayer 1.2.0" "User Commands"
 .SH NAME
 mpris-miniplayer \- control MPRIS-compatible media players
 .SH SYNOPSIS

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'mpris-miniplayer',
   ['vala', 'c'],
-  version: '1.1.1',
+  version: '1.2.0',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59.0',
 )

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -2,6 +2,7 @@ data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in
 data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in
 src/app-settings.vala
 src/background-portal.vala
+src/status-indicator.vala
 src/main.vala
 src/application.vala
 src/preferences-window.vala

--- a/po/de.po
+++ b/po/de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mpris-miniplayer 0.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-24 17:04+0200\n"
+"POT-Creation-Date: 2026-06-24 18:26+0200\n"
 "PO-Revision-Date: 2026-06-21 09:39+0200\n"
 "Last-Translator: Christian Lauinger\n"
 "Language-Team: German\n"
@@ -14,7 +14,7 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in:2
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:6
-#: src/application.vala:163 src/window.vala:38
+#: src/application.vala:167 src/window.vala:38
 msgid "MPRIS MiniPlayer"
 msgstr "MPRIS MiniPlayer"
 
@@ -84,11 +84,11 @@ msgstr "Medienspieler überwachen"
 msgid "Keep watching for MPRIS-compatible media players"
 msgstr "Weiter nach MPRIS-kompatiblen Medienspielern suchen"
 
-#: src/application.vala:210
+#: src/application.vala:218
 msgid "MPRIS MiniPlayer is running in the background"
 msgstr "MPRIS MiniPlayer läuft im Hintergrund"
 
-#: src/application.vala:212
+#: src/application.vala:220
 msgid ""
 "The window will appear automatically when a compatible media player becomes "
 "available."
@@ -96,77 +96,89 @@ msgstr ""
 "Das Fenster erscheint automatisch, sobald ein kompatibler Medienspieler "
 "verfügbar ist."
 
-#: src/application.vala:214
+#: src/application.vala:222
 msgid "Open the window when you want to control a compatible media player."
 msgstr ""
 "Öffne das Fenster, wenn du einen kompatiblen Medienspieler steuern möchtest."
 
-#: src/application.vala:216
+#: src/application.vala:224
 msgid "Open"
 msgstr "Öffnen"
 
-#: src/preferences-window.vala:12 src/preferences-window.vala:25
+#: src/preferences-window.vala:14 src/preferences-window.vala:31
 #: src/window.vala:106
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: src/preferences-window.vala:29
+#: src/preferences-window.vala:35
 msgid "Behavior"
 msgstr "Verhalten"
 
-#: src/preferences-window.vala:33
+#: src/preferences-window.vala:39
 msgid "Show and hide automatically"
 msgstr "Automatisch anzeigen und ausblenden"
 
-#: src/preferences-window.vala:34
+#: src/preferences-window.vala:40
 msgid "Show the window when a player appears and hide it when none remain"
 msgstr ""
 "Das Fenster anzeigen, wenn ein Medienspieler erscheint, und ausblenden, wenn "
 "keiner mehr verfügbar ist"
 
-#: src/preferences-window.vala:42
+#: src/preferences-window.vala:48
 msgid "Background notification"
 msgstr "Hintergrundbenachrichtigung"
 
-#: src/preferences-window.vala:43
+#: src/preferences-window.vala:49
 msgid "Notify when the app starts hidden in the background"
 msgstr "Benachrichtigen, wenn die App versteckt im Hintergrund startet"
 
-#: src/preferences-window.vala:51
+#: src/preferences-window.vala:57
 msgid "Start on login"
 msgstr "Bei Anmeldung starten"
 
-#: src/preferences-window.vala:52
+#: src/preferences-window.vala:58
 msgid "Start MPRIS MiniPlayer automatically when you log in"
 msgstr "MPRIS MiniPlayer automatisch starten, wenn du dich anmeldest"
 
-#: src/preferences-window.vala:62
+#: src/preferences-window.vala:68
 msgid "Compact mode"
 msgstr "Kompakter Modus"
 
-#: src/preferences-window.vala:63
+#: src/preferences-window.vala:69
 msgid "Use a smaller window layout"
 msgstr "Ein kleineres Fensterlayout verwenden"
 
-#: src/preferences-window.vala:71
+#: src/preferences-window.vala:77
+msgid "Status indicator"
+msgstr "Statusanzeige"
+
+#: src/preferences-window.vala:88
 msgid "Application"
 msgstr "Anwendung"
 
-#: src/preferences-window.vala:75 src/window.vala:116
+#: src/preferences-window.vala:92 src/window.vala:116
 msgid "About MPRIS MiniPlayer"
 msgstr "Info zu MPRIS MiniPlayer"
 
-#: src/preferences-window.vala:89
+#: src/preferences-window.vala:106
 msgid "Quit MPRIS MiniPlayer"
 msgstr "MPRIS MiniPlayer beenden"
 
-#: src/preferences-window.vala:90
+#: src/preferences-window.vala:107
 msgid "Stop running in the background"
 msgstr "Nicht weiter im Hintergrund laufen"
 
-#: src/preferences-window.vala:92 src/window.vala:107
+#: src/preferences-window.vala:109 src/window.vala:107
 msgid "Quit"
 msgstr "Beenden"
+
+#: src/preferences-window.vala:131
+msgid "Show an indicator when the app is running"
+msgstr "Eine Anzeige zeigen, wenn die Anwendung läuft"
+
+#: src/preferences-window.vala:132
+msgid "Not supported by this desktop"
+msgstr "Von diesem Desktop nicht unterstützt"
 
 #: src/window.vala:98
 msgid "Choose player"

--- a/po/de.po
+++ b/po/de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mpris-miniplayer 0.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-24 18:26+0200\n"
+"POT-Creation-Date: 2026-06-24 18:58+0200\n"
 "PO-Revision-Date: 2026-06-21 09:39+0200\n"
 "Last-Translator: Christian Lauinger\n"
 "Language-Team: German\n"
@@ -14,7 +14,7 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in:2
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:6
-#: src/application.vala:167 src/window.vala:38
+#: src/status-indicator.vala:37 src/application.vala:180 src/window.vala:38
 msgid "MPRIS MiniPlayer"
 msgstr "MPRIS MiniPlayer"
 
@@ -37,26 +37,50 @@ msgstr "Christian Lauinger"
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:22
 msgid ""
+"Add an optional native status indicator when the desktop supports "
+"StatusNotifierItem."
+msgstr ""
+"Eine optionale native Statusanzeige hinzufügen, wenn der Desktop "
+"StatusNotifierItem unterstützt."
+
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:23
+msgid ""
+"Add a status indicator menu with show, hide, settings, about, and quit "
+"actions."
+msgstr ""
+"Ein Menü für die Statusanzeige mit Aktionen zum Anzeigen, Ausblenden, für "
+"Einstellungen, Info und Beenden hinzufügen."
+
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:24
+msgid ""
+"Add a preference to disable the status indicator and show when the desktop "
+"does not support it."
+msgstr ""
+"Eine Einstellung zum Deaktivieren der Statusanzeige hinzufügen und anzeigen, "
+"wenn der Desktop sie nicht unterstützt."
+
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:29
+msgid ""
 "Reuse the About dialog on repeated activations without constraining it to "
 "the mini-player window."
 msgstr ""
 "Den Info-Dialog bei wiederholter Aktivierung wiederverwenden, ohne ihn auf "
 "das Mini-Player-Fenster zu beschränken."
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:27
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:34
 msgid "Add a header-bar About button and improve About dialog sizing."
 msgstr ""
 "Eine Info-Schaltfläche in der Kopfleiste hinzufügen und die Größe des Info-"
 "Dialogs verbessern."
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:28
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:35
 msgid ""
 "Document the build-tree run command with Meson's development environment."
 msgstr ""
 "Den Befehl zum Ausführen aus dem Build-Verzeichnis mit Mesons "
 "Entwicklungsumgebung dokumentieren."
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:33
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:40
 msgid ""
 "Add release packaging, icon integration, and validator-clean AppStream "
 "metadata."
@@ -64,7 +88,7 @@ msgstr ""
 "Release-Paketierung, Icon-Integration und AppStream-Metadaten ohne "
 "Validierungsfehler hinzufügen."
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:38
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:45
 msgid ""
 "Add background operation, automatic window visibility, preferences, and "
 "start-on-login support."
@@ -72,7 +96,7 @@ msgstr ""
 "Hintergrundbetrieb, automatische Fenstersichtbarkeit, Einstellungen und "
 "Unterstützung für den Start bei der Anmeldung hinzufügen."
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:43
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:50
 msgid "Initial development release."
 msgstr "Erste Entwicklungsversion."
 
@@ -84,11 +108,32 @@ msgstr "Medienspieler überwachen"
 msgid "Keep watching for MPRIS-compatible media players"
 msgstr "Weiter nach MPRIS-kompatiblen Medienspielern suchen"
 
-#: src/application.vala:218
+#: src/status-indicator.vala:248
+msgid "Hide"
+msgstr "Ausblenden"
+
+#: src/status-indicator.vala:248
+msgid "Show"
+msgstr "Anzeigen"
+
+#: src/status-indicator.vala:250 src/preferences-window.vala:14
+#: src/preferences-window.vala:31 src/window.vala:106
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: src/status-indicator.vala:252
+msgid "About"
+msgstr "Info"
+
+#: src/status-indicator.vala:254 src/window.vala:107
+msgid "Quit"
+msgstr "Beenden"
+
+#: src/application.vala:251
 msgid "MPRIS MiniPlayer is running in the background"
 msgstr "MPRIS MiniPlayer läuft im Hintergrund"
 
-#: src/application.vala:220
+#: src/application.vala:253
 msgid ""
 "The window will appear automatically when a compatible media player becomes "
 "available."
@@ -96,19 +141,14 @@ msgstr ""
 "Das Fenster erscheint automatisch, sobald ein kompatibler Medienspieler "
 "verfügbar ist."
 
-#: src/application.vala:222
+#: src/application.vala:255
 msgid "Open the window when you want to control a compatible media player."
 msgstr ""
 "Öffne das Fenster, wenn du einen kompatiblen Medienspieler steuern möchtest."
 
-#: src/application.vala:224
+#: src/application.vala:257
 msgid "Open"
 msgstr "Öffnen"
-
-#: src/preferences-window.vala:14 src/preferences-window.vala:31
-#: src/window.vala:106
-msgid "Preferences"
-msgstr "Einstellungen"
 
 #: src/preferences-window.vala:35
 msgid "Behavior"
@@ -152,31 +192,11 @@ msgstr "Ein kleineres Fensterlayout verwenden"
 msgid "Status indicator"
 msgstr "Statusanzeige"
 
-#: src/preferences-window.vala:88
-msgid "Application"
-msgstr "Anwendung"
-
-#: src/preferences-window.vala:92 src/window.vala:116
-msgid "About MPRIS MiniPlayer"
-msgstr "Info zu MPRIS MiniPlayer"
-
-#: src/preferences-window.vala:106
-msgid "Quit MPRIS MiniPlayer"
-msgstr "MPRIS MiniPlayer beenden"
-
-#: src/preferences-window.vala:107
-msgid "Stop running in the background"
-msgstr "Nicht weiter im Hintergrund laufen"
-
-#: src/preferences-window.vala:109 src/window.vala:107
-msgid "Quit"
-msgstr "Beenden"
-
-#: src/preferences-window.vala:131
+#: src/preferences-window.vala:101
 msgid "Show an indicator when the app is running"
 msgstr "Eine Anzeige zeigen, wenn die Anwendung läuft"
 
-#: src/preferences-window.vala:132
+#: src/preferences-window.vala:102
 msgid "Not supported by this desktop"
 msgstr "Von diesem Desktop nicht unterstützt"
 
@@ -191,6 +211,10 @@ msgstr "Kompakter Modus"
 #: src/window.vala:111
 msgid "Main menu"
 msgstr "Hauptmenü"
+
+#: src/window.vala:116
+msgid "About MPRIS MiniPlayer"
+msgstr "Info zu MPRIS MiniPlayer"
 
 #: src/window.vala:145
 msgid "No player running"
@@ -251,3 +275,12 @@ msgstr "Unbekannter Titel"
 #: src/mpris-player.vala:247
 msgid "Unknown artist"
 msgstr "Unbekannter Künstler"
+
+#~ msgid "Application"
+#~ msgstr "Anwendung"
+
+#~ msgid "Quit MPRIS MiniPlayer"
+#~ msgstr "MPRIS MiniPlayer beenden"
+
+#~ msgid "Stop running in the background"
+#~ msgstr "Nicht weiter im Hintergrund laufen"

--- a/po/es.po
+++ b/po/es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mpris-miniplayer 0.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-24 17:04+0200\n"
+"POT-Creation-Date: 2026-06-24 18:26+0200\n"
 "PO-Revision-Date: 2026-06-21 09:39+0200\n"
 "Last-Translator: Christian Lauinger\n"
 "Language-Team: Spanish\n"
@@ -14,7 +14,7 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in:2
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:6
-#: src/application.vala:163 src/window.vala:38
+#: src/application.vala:167 src/window.vala:38
 msgid "MPRIS MiniPlayer"
 msgstr "MPRIS MiniPlayer"
 
@@ -84,11 +84,11 @@ msgstr "Supervisando reproductores multimedia"
 msgid "Keep watching for MPRIS-compatible media players"
 msgstr "Seguir buscando reproductores multimedia compatibles con MPRIS"
 
-#: src/application.vala:210
+#: src/application.vala:218
 msgid "MPRIS MiniPlayer is running in the background"
 msgstr "MPRIS MiniPlayer se está ejecutando en segundo plano"
 
-#: src/application.vala:212
+#: src/application.vala:220
 msgid ""
 "The window will appear automatically when a compatible media player becomes "
 "available."
@@ -96,78 +96,90 @@ msgstr ""
 "La ventana aparecerá automáticamente cuando haya disponible un reproductor "
 "multimedia compatible."
 
-#: src/application.vala:214
+#: src/application.vala:222
 msgid "Open the window when you want to control a compatible media player."
 msgstr ""
 "Abre la ventana cuando quieras controlar un reproductor multimedia "
 "compatible."
 
-#: src/application.vala:216
+#: src/application.vala:224
 msgid "Open"
 msgstr "Abrir"
 
-#: src/preferences-window.vala:12 src/preferences-window.vala:25
+#: src/preferences-window.vala:14 src/preferences-window.vala:31
 #: src/window.vala:106
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: src/preferences-window.vala:29
+#: src/preferences-window.vala:35
 msgid "Behavior"
 msgstr "Comportamiento"
 
-#: src/preferences-window.vala:33
+#: src/preferences-window.vala:39
 msgid "Show and hide automatically"
 msgstr "Mostrar y ocultar automáticamente"
 
-#: src/preferences-window.vala:34
+#: src/preferences-window.vala:40
 msgid "Show the window when a player appears and hide it when none remain"
 msgstr ""
 "Mostrar la ventana cuando aparezca un reproductor y ocultarla cuando no "
 "quede ninguno"
 
-#: src/preferences-window.vala:42
+#: src/preferences-window.vala:48
 msgid "Background notification"
 msgstr "Notificación en segundo plano"
 
-#: src/preferences-window.vala:43
+#: src/preferences-window.vala:49
 msgid "Notify when the app starts hidden in the background"
 msgstr "Notificar cuando la aplicación se inicia oculta en segundo plano"
 
-#: src/preferences-window.vala:51
+#: src/preferences-window.vala:57
 msgid "Start on login"
 msgstr "Iniciar al iniciar sesión"
 
-#: src/preferences-window.vala:52
+#: src/preferences-window.vala:58
 msgid "Start MPRIS MiniPlayer automatically when you log in"
 msgstr "Iniciar MPRIS MiniPlayer automáticamente cuando inicies sesión"
 
-#: src/preferences-window.vala:62
+#: src/preferences-window.vala:68
 msgid "Compact mode"
 msgstr "Modo compacto"
 
-#: src/preferences-window.vala:63
+#: src/preferences-window.vala:69
 msgid "Use a smaller window layout"
 msgstr "Usar una disposición de ventana más pequeña"
 
-#: src/preferences-window.vala:71
+#: src/preferences-window.vala:77
+msgid "Status indicator"
+msgstr "Indicador de estado"
+
+#: src/preferences-window.vala:88
 msgid "Application"
 msgstr "Aplicación"
 
-#: src/preferences-window.vala:75 src/window.vala:116
+#: src/preferences-window.vala:92 src/window.vala:116
 msgid "About MPRIS MiniPlayer"
 msgstr "Acerca de MPRIS MiniPlayer"
 
-#: src/preferences-window.vala:89
+#: src/preferences-window.vala:106
 msgid "Quit MPRIS MiniPlayer"
 msgstr "Salir de MPRIS MiniPlayer"
 
-#: src/preferences-window.vala:90
+#: src/preferences-window.vala:107
 msgid "Stop running in the background"
 msgstr "Dejar de ejecutarse en segundo plano"
 
-#: src/preferences-window.vala:92 src/window.vala:107
+#: src/preferences-window.vala:109 src/window.vala:107
 msgid "Quit"
 msgstr "Salir"
+
+#: src/preferences-window.vala:131
+msgid "Show an indicator when the app is running"
+msgstr "Mostrar un indicador cuando la aplicación esté en ejecución"
+
+#: src/preferences-window.vala:132
+msgid "Not supported by this desktop"
+msgstr "No compatible con este escritorio"
 
 #: src/window.vala:98
 msgid "Choose player"

--- a/po/es.po
+++ b/po/es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mpris-miniplayer 0.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-24 18:26+0200\n"
+"POT-Creation-Date: 2026-06-24 18:58+0200\n"
 "PO-Revision-Date: 2026-06-21 09:39+0200\n"
 "Last-Translator: Christian Lauinger\n"
 "Language-Team: Spanish\n"
@@ -14,7 +14,7 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in:2
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:6
-#: src/application.vala:167 src/window.vala:38
+#: src/status-indicator.vala:37 src/application.vala:180 src/window.vala:38
 msgid "MPRIS MiniPlayer"
 msgstr "MPRIS MiniPlayer"
 
@@ -37,26 +37,50 @@ msgstr "Christian Lauinger"
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:22
 msgid ""
+"Add an optional native status indicator when the desktop supports "
+"StatusNotifierItem."
+msgstr ""
+"Añadir un indicador de estado nativo opcional cuando el escritorio admita "
+"StatusNotifierItem."
+
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:23
+msgid ""
+"Add a status indicator menu with show, hide, settings, about, and quit "
+"actions."
+msgstr ""
+"Añadir un menú del indicador de estado con acciones para mostrar, ocultar, "
+"configuración, acerca de y salir."
+
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:24
+msgid ""
+"Add a preference to disable the status indicator and show when the desktop "
+"does not support it."
+msgstr ""
+"Añadir una preferencia para desactivar el indicador de estado y mostrar "
+"cuando el escritorio no lo admita."
+
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:29
+msgid ""
 "Reuse the About dialog on repeated activations without constraining it to "
 "the mini-player window."
 msgstr ""
 "Reutilizar el diálogo Acerca de en activaciones repetidas sin limitarlo a la "
 "ventana del minirreproductor."
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:27
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:34
 msgid "Add a header-bar About button and improve About dialog sizing."
 msgstr ""
 "Añadir un botón Acerca de en la barra de cabecera y mejorar el tamaño del "
 "diálogo Acerca de."
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:28
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:35
 msgid ""
 "Document the build-tree run command with Meson's development environment."
 msgstr ""
 "Documentar el comando para ejecutar desde el árbol de compilación con el "
 "entorno de desarrollo de Meson."
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:33
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:40
 msgid ""
 "Add release packaging, icon integration, and validator-clean AppStream "
 "metadata."
@@ -64,7 +88,7 @@ msgstr ""
 "Añadir empaquetado de lanzamiento, integración de iconos y metadatos "
 "AppStream sin errores de validación."
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:38
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:45
 msgid ""
 "Add background operation, automatic window visibility, preferences, and "
 "start-on-login support."
@@ -72,7 +96,7 @@ msgstr ""
 "Añadir funcionamiento en segundo plano, visibilidad automática de la "
 "ventana, preferencias y compatibilidad con inicio de sesión."
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:43
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:50
 msgid "Initial development release."
 msgstr "Versión inicial de desarrollo."
 
@@ -84,11 +108,32 @@ msgstr "Supervisando reproductores multimedia"
 msgid "Keep watching for MPRIS-compatible media players"
 msgstr "Seguir buscando reproductores multimedia compatibles con MPRIS"
 
-#: src/application.vala:218
+#: src/status-indicator.vala:248
+msgid "Hide"
+msgstr "Ocultar"
+
+#: src/status-indicator.vala:248
+msgid "Show"
+msgstr "Mostrar"
+
+#: src/status-indicator.vala:250 src/preferences-window.vala:14
+#: src/preferences-window.vala:31 src/window.vala:106
+msgid "Preferences"
+msgstr "Preferencias"
+
+#: src/status-indicator.vala:252
+msgid "About"
+msgstr "Acerca de"
+
+#: src/status-indicator.vala:254 src/window.vala:107
+msgid "Quit"
+msgstr "Salir"
+
+#: src/application.vala:251
 msgid "MPRIS MiniPlayer is running in the background"
 msgstr "MPRIS MiniPlayer se está ejecutando en segundo plano"
 
-#: src/application.vala:220
+#: src/application.vala:253
 msgid ""
 "The window will appear automatically when a compatible media player becomes "
 "available."
@@ -96,20 +141,15 @@ msgstr ""
 "La ventana aparecerá automáticamente cuando haya disponible un reproductor "
 "multimedia compatible."
 
-#: src/application.vala:222
+#: src/application.vala:255
 msgid "Open the window when you want to control a compatible media player."
 msgstr ""
 "Abre la ventana cuando quieras controlar un reproductor multimedia "
 "compatible."
 
-#: src/application.vala:224
+#: src/application.vala:257
 msgid "Open"
 msgstr "Abrir"
-
-#: src/preferences-window.vala:14 src/preferences-window.vala:31
-#: src/window.vala:106
-msgid "Preferences"
-msgstr "Preferencias"
 
 #: src/preferences-window.vala:35
 msgid "Behavior"
@@ -153,31 +193,11 @@ msgstr "Usar una disposición de ventana más pequeña"
 msgid "Status indicator"
 msgstr "Indicador de estado"
 
-#: src/preferences-window.vala:88
-msgid "Application"
-msgstr "Aplicación"
-
-#: src/preferences-window.vala:92 src/window.vala:116
-msgid "About MPRIS MiniPlayer"
-msgstr "Acerca de MPRIS MiniPlayer"
-
-#: src/preferences-window.vala:106
-msgid "Quit MPRIS MiniPlayer"
-msgstr "Salir de MPRIS MiniPlayer"
-
-#: src/preferences-window.vala:107
-msgid "Stop running in the background"
-msgstr "Dejar de ejecutarse en segundo plano"
-
-#: src/preferences-window.vala:109 src/window.vala:107
-msgid "Quit"
-msgstr "Salir"
-
-#: src/preferences-window.vala:131
+#: src/preferences-window.vala:101
 msgid "Show an indicator when the app is running"
 msgstr "Mostrar un indicador cuando la aplicación esté en ejecución"
 
-#: src/preferences-window.vala:132
+#: src/preferences-window.vala:102
 msgid "Not supported by this desktop"
 msgstr "No compatible con este escritorio"
 
@@ -192,6 +212,10 @@ msgstr "Modo compacto"
 #: src/window.vala:111
 msgid "Main menu"
 msgstr "Menú principal"
+
+#: src/window.vala:116
+msgid "About MPRIS MiniPlayer"
+msgstr "Acerca de MPRIS MiniPlayer"
 
 #: src/window.vala:145
 msgid "No player running"
@@ -252,3 +276,12 @@ msgstr "Pista desconocida"
 #: src/mpris-player.vala:247
 msgid "Unknown artist"
 msgstr "Artista desconocido"
+
+#~ msgid "Application"
+#~ msgstr "Aplicación"
+
+#~ msgid "Quit MPRIS MiniPlayer"
+#~ msgstr "Salir de MPRIS MiniPlayer"
+
+#~ msgid "Stop running in the background"
+#~ msgstr "Dejar de ejecutarse en segundo plano"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mpris-miniplayer 0.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-24 17:04+0200\n"
+"POT-Creation-Date: 2026-06-24 18:26+0200\n"
 "PO-Revision-Date: 2026-06-21 09:39+0200\n"
 "Last-Translator: Christian Lauinger\n"
 "Language-Team: French\n"
@@ -14,7 +14,7 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in:2
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:6
-#: src/application.vala:163 src/window.vala:38
+#: src/application.vala:167 src/window.vala:38
 msgid "MPRIS MiniPlayer"
 msgstr "MPRIS MiniPlayer"
 
@@ -84,11 +84,11 @@ msgstr "Surveillance des lecteurs multimédias"
 msgid "Keep watching for MPRIS-compatible media players"
 msgstr "Continuer à surveiller les lecteurs multimédias compatibles MPRIS"
 
-#: src/application.vala:210
+#: src/application.vala:218
 msgid "MPRIS MiniPlayer is running in the background"
 msgstr "MPRIS MiniPlayer s’exécute en arrière-plan"
 
-#: src/application.vala:212
+#: src/application.vala:220
 msgid ""
 "The window will appear automatically when a compatible media player becomes "
 "available."
@@ -96,78 +96,90 @@ msgstr ""
 "La fenêtre apparaîtra automatiquement lorsqu’un lecteur multimédia "
 "compatible sera disponible."
 
-#: src/application.vala:214
+#: src/application.vala:222
 msgid "Open the window when you want to control a compatible media player."
 msgstr ""
 "Ouvrez la fenêtre lorsque vous souhaitez contrôler un lecteur multimédia "
 "compatible."
 
-#: src/application.vala:216
+#: src/application.vala:224
 msgid "Open"
 msgstr "Ouvrir"
 
-#: src/preferences-window.vala:12 src/preferences-window.vala:25
+#: src/preferences-window.vala:14 src/preferences-window.vala:31
 #: src/window.vala:106
 msgid "Preferences"
 msgstr "Préférences"
 
-#: src/preferences-window.vala:29
+#: src/preferences-window.vala:35
 msgid "Behavior"
 msgstr "Comportement"
 
-#: src/preferences-window.vala:33
+#: src/preferences-window.vala:39
 msgid "Show and hide automatically"
 msgstr "Afficher et masquer automatiquement"
 
-#: src/preferences-window.vala:34
+#: src/preferences-window.vala:40
 msgid "Show the window when a player appears and hide it when none remain"
 msgstr ""
 "Afficher la fenêtre lorsqu’un lecteur apparaît et la masquer lorsqu’il n’en "
 "reste aucun"
 
-#: src/preferences-window.vala:42
+#: src/preferences-window.vala:48
 msgid "Background notification"
 msgstr "Notification en arrière-plan"
 
-#: src/preferences-window.vala:43
+#: src/preferences-window.vala:49
 msgid "Notify when the app starts hidden in the background"
 msgstr "Notifier lorsque l’application démarre masquée en arrière-plan"
 
-#: src/preferences-window.vala:51
+#: src/preferences-window.vala:57
 msgid "Start on login"
 msgstr "Démarrer à la connexion"
 
-#: src/preferences-window.vala:52
+#: src/preferences-window.vala:58
 msgid "Start MPRIS MiniPlayer automatically when you log in"
 msgstr "Démarrer MPRIS MiniPlayer automatiquement à la connexion"
 
-#: src/preferences-window.vala:62
+#: src/preferences-window.vala:68
 msgid "Compact mode"
 msgstr "Mode compact"
 
-#: src/preferences-window.vala:63
+#: src/preferences-window.vala:69
 msgid "Use a smaller window layout"
 msgstr "Utiliser une disposition de fenêtre plus petite"
 
-#: src/preferences-window.vala:71
+#: src/preferences-window.vala:77
+msgid "Status indicator"
+msgstr "Indicateur d’état"
+
+#: src/preferences-window.vala:88
 msgid "Application"
 msgstr "Application"
 
-#: src/preferences-window.vala:75 src/window.vala:116
+#: src/preferences-window.vala:92 src/window.vala:116
 msgid "About MPRIS MiniPlayer"
 msgstr "À propos de MPRIS MiniPlayer"
 
-#: src/preferences-window.vala:89
+#: src/preferences-window.vala:106
 msgid "Quit MPRIS MiniPlayer"
 msgstr "Quitter MPRIS MiniPlayer"
 
-#: src/preferences-window.vala:90
+#: src/preferences-window.vala:107
 msgid "Stop running in the background"
 msgstr "Arrêter l’exécution en arrière-plan"
 
-#: src/preferences-window.vala:92 src/window.vala:107
+#: src/preferences-window.vala:109 src/window.vala:107
 msgid "Quit"
 msgstr "Quitter"
+
+#: src/preferences-window.vala:131
+msgid "Show an indicator when the app is running"
+msgstr "Afficher un indicateur lorsque l’application est en cours d’exécution"
+
+#: src/preferences-window.vala:132
+msgid "Not supported by this desktop"
+msgstr "Non pris en charge par ce bureau"
 
 #: src/window.vala:98
 msgid "Choose player"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mpris-miniplayer 0.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-24 18:26+0200\n"
+"POT-Creation-Date: 2026-06-24 18:58+0200\n"
 "PO-Revision-Date: 2026-06-21 09:39+0200\n"
 "Last-Translator: Christian Lauinger\n"
 "Language-Team: French\n"
@@ -14,7 +14,7 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in:2
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:6
-#: src/application.vala:167 src/window.vala:38
+#: src/status-indicator.vala:37 src/application.vala:180 src/window.vala:38
 msgid "MPRIS MiniPlayer"
 msgstr "MPRIS MiniPlayer"
 
@@ -37,26 +37,50 @@ msgstr "Christian Lauinger"
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:22
 msgid ""
+"Add an optional native status indicator when the desktop supports "
+"StatusNotifierItem."
+msgstr ""
+"Ajouter un indicateur d’état natif facultatif lorsque le bureau prend en "
+"charge StatusNotifierItem."
+
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:23
+msgid ""
+"Add a status indicator menu with show, hide, settings, about, and quit "
+"actions."
+msgstr ""
+"Ajouter un menu d’indicateur d’état avec des actions pour afficher, masquer, "
+"les paramètres, à propos et quitter."
+
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:24
+msgid ""
+"Add a preference to disable the status indicator and show when the desktop "
+"does not support it."
+msgstr ""
+"Ajouter une préférence pour désactiver l’indicateur d’état et indiquer quand "
+"le bureau ne le prend pas en charge."
+
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:29
+msgid ""
 "Reuse the About dialog on repeated activations without constraining it to "
 "the mini-player window."
 msgstr ""
 "Réutiliser la boîte de dialogue À propos lors des activations répétées sans "
 "la contraindre à la fenêtre du mini-lecteur."
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:27
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:34
 msgid "Add a header-bar About button and improve About dialog sizing."
 msgstr ""
 "Ajouter un bouton À propos dans la barre d’en-tête et améliorer la taille de "
 "la boîte de dialogue À propos."
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:28
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:35
 msgid ""
 "Document the build-tree run command with Meson's development environment."
 msgstr ""
 "Documenter la commande d’exécution depuis l’arbre de compilation avec "
 "l’environnement de développement de Meson."
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:33
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:40
 msgid ""
 "Add release packaging, icon integration, and validator-clean AppStream "
 "metadata."
@@ -64,7 +88,7 @@ msgstr ""
 "Ajouter l’empaquetage de version, l’intégration de l’icône et des "
 "métadonnées AppStream valides."
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:38
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:45
 msgid ""
 "Add background operation, automatic window visibility, preferences, and "
 "start-on-login support."
@@ -72,7 +96,7 @@ msgstr ""
 "Ajouter le fonctionnement en arrière-plan, la visibilité automatique de la "
 "fenêtre, les préférences et la prise en charge du démarrage à la connexion."
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:43
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:50
 msgid "Initial development release."
 msgstr "Première version de développement."
 
@@ -84,11 +108,32 @@ msgstr "Surveillance des lecteurs multimédias"
 msgid "Keep watching for MPRIS-compatible media players"
 msgstr "Continuer à surveiller les lecteurs multimédias compatibles MPRIS"
 
-#: src/application.vala:218
+#: src/status-indicator.vala:248
+msgid "Hide"
+msgstr "Masquer"
+
+#: src/status-indicator.vala:248
+msgid "Show"
+msgstr "Afficher"
+
+#: src/status-indicator.vala:250 src/preferences-window.vala:14
+#: src/preferences-window.vala:31 src/window.vala:106
+msgid "Preferences"
+msgstr "Préférences"
+
+#: src/status-indicator.vala:252
+msgid "About"
+msgstr "À propos"
+
+#: src/status-indicator.vala:254 src/window.vala:107
+msgid "Quit"
+msgstr "Quitter"
+
+#: src/application.vala:251
 msgid "MPRIS MiniPlayer is running in the background"
 msgstr "MPRIS MiniPlayer s’exécute en arrière-plan"
 
-#: src/application.vala:220
+#: src/application.vala:253
 msgid ""
 "The window will appear automatically when a compatible media player becomes "
 "available."
@@ -96,20 +141,15 @@ msgstr ""
 "La fenêtre apparaîtra automatiquement lorsqu’un lecteur multimédia "
 "compatible sera disponible."
 
-#: src/application.vala:222
+#: src/application.vala:255
 msgid "Open the window when you want to control a compatible media player."
 msgstr ""
 "Ouvrez la fenêtre lorsque vous souhaitez contrôler un lecteur multimédia "
 "compatible."
 
-#: src/application.vala:224
+#: src/application.vala:257
 msgid "Open"
 msgstr "Ouvrir"
-
-#: src/preferences-window.vala:14 src/preferences-window.vala:31
-#: src/window.vala:106
-msgid "Preferences"
-msgstr "Préférences"
 
 #: src/preferences-window.vala:35
 msgid "Behavior"
@@ -153,31 +193,11 @@ msgstr "Utiliser une disposition de fenêtre plus petite"
 msgid "Status indicator"
 msgstr "Indicateur d’état"
 
-#: src/preferences-window.vala:88
-msgid "Application"
-msgstr "Application"
-
-#: src/preferences-window.vala:92 src/window.vala:116
-msgid "About MPRIS MiniPlayer"
-msgstr "À propos de MPRIS MiniPlayer"
-
-#: src/preferences-window.vala:106
-msgid "Quit MPRIS MiniPlayer"
-msgstr "Quitter MPRIS MiniPlayer"
-
-#: src/preferences-window.vala:107
-msgid "Stop running in the background"
-msgstr "Arrêter l’exécution en arrière-plan"
-
-#: src/preferences-window.vala:109 src/window.vala:107
-msgid "Quit"
-msgstr "Quitter"
-
-#: src/preferences-window.vala:131
+#: src/preferences-window.vala:101
 msgid "Show an indicator when the app is running"
 msgstr "Afficher un indicateur lorsque l’application est en cours d’exécution"
 
-#: src/preferences-window.vala:132
+#: src/preferences-window.vala:102
 msgid "Not supported by this desktop"
 msgstr "Non pris en charge par ce bureau"
 
@@ -192,6 +212,10 @@ msgstr "Mode compact"
 #: src/window.vala:111
 msgid "Main menu"
 msgstr "Menu principal"
+
+#: src/window.vala:116
+msgid "About MPRIS MiniPlayer"
+msgstr "À propos de MPRIS MiniPlayer"
 
 #: src/window.vala:145
 msgid "No player running"
@@ -252,3 +276,12 @@ msgstr "Titre inconnu"
 #: src/mpris-player.vala:247
 msgid "Unknown artist"
 msgstr "Artiste inconnu"
+
+#~ msgid "Application"
+#~ msgstr "Application"
+
+#~ msgid "Quit MPRIS MiniPlayer"
+#~ msgstr "Quitter MPRIS MiniPlayer"
+
+#~ msgid "Stop running in the background"
+#~ msgstr "Arrêter l’exécution en arrière-plan"

--- a/po/mpris-miniplayer.pot
+++ b/po/mpris-miniplayer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mpris-miniplayer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-24 17:04+0200\n"
+"POT-Creation-Date: 2026-06-24 18:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in:2
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:6
-#: src/application.vala:163 src/window.vala:38
+#: src/application.vala:167 src/window.vala:38
 msgid "MPRIS MiniPlayer"
 msgstr ""
 
@@ -77,83 +77,95 @@ msgstr ""
 msgid "Keep watching for MPRIS-compatible media players"
 msgstr ""
 
-#: src/application.vala:210
+#: src/application.vala:218
 msgid "MPRIS MiniPlayer is running in the background"
 msgstr ""
 
-#: src/application.vala:212
+#: src/application.vala:220
 msgid ""
 "The window will appear automatically when a compatible media player becomes "
 "available."
 msgstr ""
 
-#: src/application.vala:214
+#: src/application.vala:222
 msgid "Open the window when you want to control a compatible media player."
 msgstr ""
 
-#: src/application.vala:216
+#: src/application.vala:224
 msgid "Open"
 msgstr ""
 
-#: src/preferences-window.vala:12 src/preferences-window.vala:25
+#: src/preferences-window.vala:14 src/preferences-window.vala:31
 #: src/window.vala:106
 msgid "Preferences"
 msgstr ""
 
-#: src/preferences-window.vala:29
+#: src/preferences-window.vala:35
 msgid "Behavior"
 msgstr ""
 
-#: src/preferences-window.vala:33
+#: src/preferences-window.vala:39
 msgid "Show and hide automatically"
 msgstr ""
 
-#: src/preferences-window.vala:34
+#: src/preferences-window.vala:40
 msgid "Show the window when a player appears and hide it when none remain"
 msgstr ""
 
-#: src/preferences-window.vala:42
+#: src/preferences-window.vala:48
 msgid "Background notification"
 msgstr ""
 
-#: src/preferences-window.vala:43
+#: src/preferences-window.vala:49
 msgid "Notify when the app starts hidden in the background"
 msgstr ""
 
-#: src/preferences-window.vala:51
+#: src/preferences-window.vala:57
 msgid "Start on login"
 msgstr ""
 
-#: src/preferences-window.vala:52
+#: src/preferences-window.vala:58
 msgid "Start MPRIS MiniPlayer automatically when you log in"
 msgstr ""
 
-#: src/preferences-window.vala:62
+#: src/preferences-window.vala:68
 msgid "Compact mode"
 msgstr ""
 
-#: src/preferences-window.vala:63
+#: src/preferences-window.vala:69
 msgid "Use a smaller window layout"
 msgstr ""
 
-#: src/preferences-window.vala:71
+#: src/preferences-window.vala:77
+msgid "Status indicator"
+msgstr ""
+
+#: src/preferences-window.vala:88
 msgid "Application"
 msgstr ""
 
-#: src/preferences-window.vala:75 src/window.vala:116
+#: src/preferences-window.vala:92 src/window.vala:116
 msgid "About MPRIS MiniPlayer"
 msgstr ""
 
-#: src/preferences-window.vala:89
+#: src/preferences-window.vala:106
 msgid "Quit MPRIS MiniPlayer"
 msgstr ""
 
-#: src/preferences-window.vala:90
+#: src/preferences-window.vala:107
 msgid "Stop running in the background"
 msgstr ""
 
-#: src/preferences-window.vala:92 src/window.vala:107
+#: src/preferences-window.vala:109 src/window.vala:107
 msgid "Quit"
+msgstr ""
+
+#: src/preferences-window.vala:131
+msgid "Show an indicator when the app is running"
+msgstr ""
+
+#: src/preferences-window.vala:132
+msgid "Not supported by this desktop"
 msgstr ""
 
 #: src/window.vala:98

--- a/po/mpris-miniplayer.pot
+++ b/po/mpris-miniplayer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mpris-miniplayer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-24 18:26+0200\n"
+"POT-Creation-Date: 2026-06-24 18:58+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in:2
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:6
-#: src/application.vala:167 src/window.vala:38
+#: src/status-indicator.vala:37 src/application.vala:180 src/window.vala:38
 msgid "MPRIS MiniPlayer"
 msgstr ""
 
@@ -40,32 +40,50 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:22
 msgid ""
+"Add an optional native status indicator when the desktop supports "
+"StatusNotifierItem."
+msgstr ""
+
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:23
+msgid ""
+"Add a status indicator menu with show, hide, settings, about, and quit "
+"actions."
+msgstr ""
+
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:24
+msgid ""
+"Add a preference to disable the status indicator and show when the desktop "
+"does not support it."
+msgstr ""
+
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:29
+msgid ""
 "Reuse the About dialog on repeated activations without constraining it to "
 "the mini-player window."
 msgstr ""
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:27
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:34
 msgid "Add a header-bar About button and improve About dialog sizing."
 msgstr ""
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:28
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:35
 msgid ""
 "Document the build-tree run command with Meson's development environment."
 msgstr ""
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:33
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:40
 msgid ""
 "Add release packaging, icon integration, and validator-clean AppStream "
 "metadata."
 msgstr ""
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:38
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:45
 msgid ""
 "Add background operation, automatic window visibility, preferences, and "
 "start-on-login support."
 msgstr ""
 
-#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:43
+#: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:50
 msgid "Initial development release."
 msgstr ""
 
@@ -77,27 +95,43 @@ msgstr ""
 msgid "Keep watching for MPRIS-compatible media players"
 msgstr ""
 
-#: src/application.vala:218
+#: src/status-indicator.vala:248
+msgid "Hide"
+msgstr ""
+
+#: src/status-indicator.vala:248
+msgid "Show"
+msgstr ""
+
+#: src/status-indicator.vala:250 src/preferences-window.vala:14
+#: src/preferences-window.vala:31 src/window.vala:106
+msgid "Preferences"
+msgstr ""
+
+#: src/status-indicator.vala:252
+msgid "About"
+msgstr ""
+
+#: src/status-indicator.vala:254 src/window.vala:107
+msgid "Quit"
+msgstr ""
+
+#: src/application.vala:251
 msgid "MPRIS MiniPlayer is running in the background"
 msgstr ""
 
-#: src/application.vala:220
+#: src/application.vala:253
 msgid ""
 "The window will appear automatically when a compatible media player becomes "
 "available."
 msgstr ""
 
-#: src/application.vala:222
+#: src/application.vala:255
 msgid "Open the window when you want to control a compatible media player."
 msgstr ""
 
-#: src/application.vala:224
+#: src/application.vala:257
 msgid "Open"
-msgstr ""
-
-#: src/preferences-window.vala:14 src/preferences-window.vala:31
-#: src/window.vala:106
-msgid "Preferences"
 msgstr ""
 
 #: src/preferences-window.vala:35
@@ -140,31 +174,11 @@ msgstr ""
 msgid "Status indicator"
 msgstr ""
 
-#: src/preferences-window.vala:88
-msgid "Application"
-msgstr ""
-
-#: src/preferences-window.vala:92 src/window.vala:116
-msgid "About MPRIS MiniPlayer"
-msgstr ""
-
-#: src/preferences-window.vala:106
-msgid "Quit MPRIS MiniPlayer"
-msgstr ""
-
-#: src/preferences-window.vala:107
-msgid "Stop running in the background"
-msgstr ""
-
-#: src/preferences-window.vala:109 src/window.vala:107
-msgid "Quit"
-msgstr ""
-
-#: src/preferences-window.vala:131
+#: src/preferences-window.vala:101
 msgid "Show an indicator when the app is running"
 msgstr ""
 
-#: src/preferences-window.vala:132
+#: src/preferences-window.vala:102
 msgid "Not supported by this desktop"
 msgstr ""
 
@@ -178,6 +192,10 @@ msgstr ""
 
 #: src/window.vala:111
 msgid "Main menu"
+msgstr ""
+
+#: src/window.vala:116
+msgid "About MPRIS MiniPlayer"
 msgstr ""
 
 #: src/window.vala:145

--- a/src/app-settings.vala
+++ b/src/app-settings.vala
@@ -5,19 +5,24 @@ namespace MprisMiniPlayer {
         private const string KEY_START_ON_LOGIN = "start-on-login";
         private const string KEY_AUTOMATIC_WINDOW_VISIBILITY = "automatic-window-visibility";
         private const string KEY_COMPACT_MODE = "compact-mode";
+        private const string KEY_SHOW_STATUS_INDICATOR = "show-status-indicator";
 
         private GLib.Settings? settings;
         private bool fallback_show_background_notification = true;
         private bool fallback_start_on_login = false;
         private bool fallback_automatic_window_visibility = true;
         private bool fallback_compact_mode = false;
+        private bool fallback_show_status_indicator = true;
+        private bool has_show_status_indicator_key = false;
         private bool syncing = false;
 
         public signal void changed(string key);
 
         public AppSettings() {
             SettingsSchemaSource? source = SettingsSchemaSource.get_default();
-            if (source != null && source.lookup(SCHEMA_ID, true) != null) {
+            SettingsSchema? schema = source != null ? source.lookup(SCHEMA_ID, true) : null;
+            if (schema != null) {
+                has_show_status_indicator_key = schema.has_key(KEY_SHOW_STATUS_INDICATOR);
                 settings = new GLib.Settings(SCHEMA_ID);
                 settings.changed.connect(on_settings_changed);
             } else {
@@ -94,6 +99,24 @@ namespace MprisMiniPlayer {
                 } else if (fallback_compact_mode != value) {
                     fallback_compact_mode = value;
                     changed(KEY_COMPACT_MODE);
+                }
+            }
+        }
+
+        public bool show_status_indicator {
+            get {
+                if (settings != null && has_show_status_indicator_key) {
+                    return settings.get_boolean(KEY_SHOW_STATUS_INDICATOR);
+                }
+
+                return fallback_show_status_indicator;
+            }
+            set {
+                if (settings != null && has_show_status_indicator_key) {
+                    settings.set_boolean(KEY_SHOW_STATUS_INDICATOR, value);
+                } else if (fallback_show_status_indicator != value) {
+                    fallback_show_status_indicator = value;
+                    changed(KEY_SHOW_STATUS_INDICATOR);
                 }
             }
         }

--- a/src/application.vala
+++ b/src/application.vala
@@ -34,6 +34,7 @@ namespace MprisMiniPlayer {
             setup_actions();
             status_indicator = new StatusIndicator();
             status_indicator.activated.connect(() => present_window());
+            status_indicator.action_requested.connect(on_status_indicator_action_requested);
             status_indicator.set_enabled(app_settings.show_status_indicator);
 
             try {
@@ -59,6 +60,10 @@ namespace MprisMiniPlayer {
             var open_action = new SimpleAction("open", null);
             open_action.activate.connect(() => present_window());
             add_action(open_action);
+
+            var hide_action = new SimpleAction("hide", null);
+            hide_action.activate.connect(() => hide_window());
+            add_action(hide_action);
 
             var preferences_action = new SimpleAction("preferences", null);
             preferences_action.activate.connect(() => present_preferences());
@@ -114,8 +119,7 @@ namespace MprisMiniPlayer {
             if (players_available) {
                 present_window();
             } else if (main_window != null) {
-                main_window.set_visible(false);
-                enter_background();
+                hide_window();
             }
         }
 
@@ -133,16 +137,25 @@ namespace MprisMiniPlayer {
             if (main_window == null) {
                 main_window = new Window(this, manager, app_settings.compact_mode);
                 main_window.close_request.connect(() => {
-                    main_window.set_visible(false);
-                    enter_background();
+                    hide_window();
                     return true;
                 });
             }
 
             main_window.refresh_players();
             main_window.present();
+            status_indicator.set_window_visible(true);
             background_portal.leave_background();
             withdraw_notification(BACKGROUND_NOTIFICATION_ID);
+        }
+
+        private void hide_window() {
+            if (main_window != null) {
+                main_window.set_visible(false);
+            }
+
+            status_indicator.set_window_visible(false);
+            enter_background();
         }
 
         private void present_preferences() {
@@ -207,6 +220,26 @@ namespace MprisMiniPlayer {
             if (app_settings.start_on_login != enabled) {
                 suppress_next_start_on_login_portal_update = true;
                 app_settings.start_on_login = enabled;
+            }
+        }
+
+        private void on_status_indicator_action_requested(string action) {
+            switch (action) {
+                case "show":
+                    present_window();
+                    break;
+                case "hide":
+                    hide_window();
+                    break;
+                case "preferences":
+                    present_preferences();
+                    break;
+                case "about":
+                    present_about();
+                    break;
+                case "quit":
+                    quit_app();
+                    break;
             }
         }
 

--- a/src/application.vala
+++ b/src/application.vala
@@ -4,6 +4,7 @@ namespace MprisMiniPlayer {
 
         private AppSettings app_settings;
         private BackgroundPortal background_portal;
+        private StatusIndicator status_indicator;
         private MprisManager? manager;
         private Window? main_window;
         private PreferencesWindow? preferences_window;
@@ -31,6 +32,9 @@ namespace MprisMiniPlayer {
             background_portal = new BackgroundPortal();
             background_portal.autostart_changed.connect(on_portal_autostart_changed);
             setup_actions();
+            status_indicator = new StatusIndicator();
+            status_indicator.activated.connect(() => present_window());
+            status_indicator.set_enabled(app_settings.show_status_indicator);
 
             try {
                 manager = new MprisManager();
@@ -143,7 +147,7 @@ namespace MprisMiniPlayer {
 
         private void present_preferences() {
             if (preferences_window == null) {
-                preferences_window = new PreferencesWindow(this, app_settings);
+                preferences_window = new PreferencesWindow(this, app_settings, status_indicator);
                 preferences_window.close_request.connect(() => {
                     preferences_window = null;
                     return false;
@@ -186,6 +190,10 @@ namespace MprisMiniPlayer {
                 }
             }
 
+            if (key == "show-status-indicator") {
+                status_indicator.set_enabled(app_settings.show_status_indicator);
+            }
+
             bool compact_mode = app_settings.compact_mode;
             if (compact_mode_action != null) {
                 compact_mode_action.set_state(new Variant.boolean(compact_mode));
@@ -225,6 +233,7 @@ namespace MprisMiniPlayer {
         private void quit_app() {
             withdraw_notification(BACKGROUND_NOTIFICATION_ID);
             background_portal.leave_background();
+            status_indicator.shutdown();
 
             if (held) {
                 release();

--- a/src/meson.build
+++ b/src/meson.build
@@ -17,6 +17,7 @@ executable(
     'main.vala',
     'app-settings.vala',
     'background-portal.vala',
+    'status-indicator.vala',
     'application.vala',
     'preferences-window.vala',
     'window.vala',

--- a/src/preferences-window.vala
+++ b/src/preferences-window.vala
@@ -5,8 +5,10 @@ namespace MprisMiniPlayer {
         private Adw.SwitchRow autostart_row;
         private Adw.SwitchRow automatic_visibility_row;
         private Adw.SwitchRow compact_mode_row;
+        private Adw.SwitchRow status_indicator_row;
+        private StatusIndicator? status_indicator;
 
-        public PreferencesWindow(Gtk.Application app, AppSettings app_settings) {
+        public PreferencesWindow(Gtk.Application app, AppSettings app_settings, StatusIndicator? status_indicator) {
             Object(
                 application: app,
                 title: _("Preferences"),
@@ -15,9 +17,13 @@ namespace MprisMiniPlayer {
             );
 
             this.app_settings = app_settings;
+            this.status_indicator = status_indicator;
 
             build_ui(app);
             app_settings.changed.connect(sync_rows);
+            if (status_indicator != null) {
+                status_indicator.support_changed.connect(() => sync_rows("show-status-indicator"));
+            }
         }
 
         private void build_ui(Gtk.Application app) {
@@ -67,6 +73,17 @@ namespace MprisMiniPlayer {
             });
             behavior_group.add(compact_mode_row);
 
+            status_indicator_row = new Adw.SwitchRow();
+            status_indicator_row.title = _("Status indicator");
+            status_indicator_row.active = app_settings.show_status_indicator;
+            status_indicator_row.notify["active"].connect(() => {
+                if (status_indicator_is_supported()) {
+                    app_settings.show_status_indicator = status_indicator_row.active;
+                }
+            });
+            behavior_group.add(status_indicator_row);
+            sync_status_indicator_row();
+
             var app_group = new Adw.PreferencesGroup();
             app_group.title = _("Application");
             page.add(app_group);
@@ -103,6 +120,20 @@ namespace MprisMiniPlayer {
             autostart_row.active = app_settings.start_on_login;
             automatic_visibility_row.active = app_settings.automatic_window_visibility;
             compact_mode_row.active = app_settings.compact_mode;
+            sync_status_indicator_row();
+        }
+
+        private void sync_status_indicator_row() {
+            bool supported = status_indicator_is_supported();
+            status_indicator_row.sensitive = supported;
+            status_indicator_row.active = supported && app_settings.show_status_indicator;
+            status_indicator_row.subtitle = supported
+                ? _("Show an indicator when the app is running")
+                : _("Not supported by this desktop");
+        }
+
+        private bool status_indicator_is_supported() {
+            return status_indicator != null && status_indicator.supported;
         }
     }
 }

--- a/src/preferences-window.vala
+++ b/src/preferences-window.vala
@@ -19,14 +19,14 @@ namespace MprisMiniPlayer {
             this.app_settings = app_settings;
             this.status_indicator = status_indicator;
 
-            build_ui(app);
+            build_ui();
             app_settings.changed.connect(sync_rows);
             if (status_indicator != null) {
                 status_indicator.support_changed.connect(() => sync_rows("show-status-indicator"));
             }
         }
 
-        private void build_ui(Gtk.Application app) {
+        private void build_ui() {
             var page = new Adw.PreferencesPage();
             page.title = _("Preferences");
             add(page);
@@ -83,36 +83,6 @@ namespace MprisMiniPlayer {
             });
             behavior_group.add(status_indicator_row);
             sync_status_indicator_row();
-
-            var app_group = new Adw.PreferencesGroup();
-            app_group.title = _("Application");
-            page.add(app_group);
-
-            var about_row = new Adw.ActionRow();
-            about_row.title = _("About MPRIS MiniPlayer");
-            about_row.activatable = true;
-            about_row.activated.connect(() => app.activate_action("about", null));
-
-            var about_icon = new Gtk.Image.from_icon_name("help-about-symbolic");
-            about_icon.valign = Gtk.Align.CENTER;
-            about_row.add_prefix(about_icon);
-
-            var about_arrow = new Gtk.Image.from_icon_name("go-next-symbolic");
-            about_arrow.valign = Gtk.Align.CENTER;
-            about_row.add_suffix(about_arrow);
-            app_group.add(about_row);
-
-            var quit_row = new Adw.ActionRow();
-            quit_row.title = _("Quit MPRIS MiniPlayer");
-            quit_row.subtitle = _("Stop running in the background");
-
-            var quit_button = new Gtk.Button.with_label(_("Quit"));
-            quit_button.valign = Gtk.Align.CENTER;
-            quit_button.add_css_class("destructive-action");
-            quit_button.clicked.connect(() => app.activate_action("quit", null));
-            quit_row.add_suffix(quit_button);
-            quit_row.activatable_widget = quit_button;
-            app_group.add(quit_row);
         }
 
         private void sync_rows(string key) {

--- a/src/status-indicator.vala
+++ b/src/status-indicator.vala
@@ -1,0 +1,283 @@
+namespace MprisMiniPlayer {
+    [DBus (name = "org.kde.StatusNotifierWatcher")]
+    private interface StatusNotifierWatcher : Object {
+        public abstract void RegisterStatusNotifierItem(string service) throws DBusError, IOError;
+    }
+
+    [DBus (name = "org.kde.StatusNotifierItem")]
+    public class StatusNotifierItem : Object {
+        private const string APP_ID = "io.github.ChrisLauinger.MprisMiniPlayer";
+
+        public signal void activated();
+
+        [DBus (name = "NewIcon")]
+        public signal void new_icon();
+
+        [DBus (name = "NewTitle")]
+        public signal void new_title();
+
+        [DBus (name = "Category")]
+        public string category {
+            owned get {
+                return "ApplicationStatus";
+            }
+        }
+
+        [DBus (name = "Id")]
+        public string id {
+            owned get {
+                return APP_ID;
+            }
+        }
+
+        [DBus (name = "Title")]
+        public string title {
+            owned get {
+                return _("MPRIS MiniPlayer");
+            }
+        }
+
+        [DBus (name = "Status")]
+        public string status {
+            owned get {
+                return "Active";
+            }
+        }
+
+        [DBus (name = "IconName")]
+        public string icon_name {
+            owned get {
+                return APP_ID;
+            }
+        }
+
+        [DBus (name = "ItemIsMenu")]
+        public bool item_is_menu {
+            get {
+                return false;
+            }
+        }
+
+        [DBus (name = "Menu")]
+        public ObjectPath menu {
+            owned get {
+                return new ObjectPath("/");
+            }
+        }
+
+        [DBus (name = "WindowId")]
+        public uint32 window_id {
+            get {
+                return 0;
+            }
+        }
+
+        [DBus (name = "OverlayIconName")]
+        public string overlay_icon_name {
+            owned get {
+                return "";
+            }
+        }
+
+        [DBus (name = "AttentionIconName")]
+        public string attention_icon_name {
+            owned get {
+                return "";
+            }
+        }
+
+        [DBus (name = "AttentionMovieName")]
+        public string attention_movie_name {
+            owned get {
+                return "";
+            }
+        }
+
+        [DBus (name = "Activate")]
+        public void activate(int x, int y) throws DBusError, IOError {
+            activated();
+        }
+
+        [DBus (name = "ContextMenu")]
+        public void context_menu(int x, int y) throws DBusError, IOError {
+            activated();
+        }
+
+        [DBus (name = "SecondaryActivate")]
+        public void secondary_activate(int x, int y) throws DBusError, IOError {
+            activated();
+        }
+
+        [DBus (name = "Scroll")]
+        public void scroll(int delta, string orientation) throws DBusError, IOError {
+        }
+    }
+
+    public class StatusIndicator : Object {
+        private const string WATCHER_BUS_NAME = "org.kde.StatusNotifierWatcher";
+        private const string WATCHER_OBJECT_PATH = "/StatusNotifierWatcher";
+        private const string WATCHER_IFACE = "org.kde.StatusNotifierWatcher";
+        private const string DBUS_BUS_NAME = "org.freedesktop.DBus";
+        private const string DBUS_OBJECT_PATH = "/org/freedesktop/DBus";
+        private const string DBUS_IFACE = "org.freedesktop.DBus";
+        private const string ITEM_OBJECT_PATH = "/StatusNotifierItem";
+
+        private DBusConnection? bus;
+        private StatusNotifierItem? item;
+        private uint item_registration_id = 0;
+        private uint name_owner_subscription_id = 0;
+        private bool enabled = false;
+
+        public bool supported { get; private set; default = false; }
+
+        public signal void support_changed();
+        public signal void activated();
+
+        public StatusIndicator() {
+            if (is_flatpak()) {
+                return;
+            }
+
+            try {
+                bus = Bus.get_sync(BusType.SESSION);
+            } catch (Error error) {
+                warning("Unable to connect to the session bus for the status indicator: %s", error.message);
+                return;
+            }
+
+            subscribe_name_owner_changes();
+            refresh_supported();
+        }
+
+        public void set_enabled(bool enabled) {
+            this.enabled = enabled;
+            update_registration();
+        }
+
+        public void shutdown() {
+            if (bus != null && name_owner_subscription_id != 0) {
+                bus.signal_unsubscribe(name_owner_subscription_id);
+                name_owner_subscription_id = 0;
+            }
+
+            unregister_item();
+        }
+
+        private void subscribe_name_owner_changes() {
+            name_owner_subscription_id = bus.signal_subscribe(
+                DBUS_BUS_NAME,
+                DBUS_IFACE,
+                "NameOwnerChanged",
+                DBUS_OBJECT_PATH,
+                WATCHER_BUS_NAME,
+                DBusSignalFlags.NONE,
+                on_name_owner_changed
+            );
+        }
+
+        private void on_name_owner_changed(
+            DBusConnection connection,
+            string? sender_name,
+            string object_path,
+            string interface_name,
+            string signal_name,
+            Variant parameters
+        ) {
+            refresh_supported();
+        }
+
+        private void refresh_supported() {
+            bool old_supported = supported;
+            supported = name_has_owner(WATCHER_BUS_NAME);
+
+            if (old_supported != supported) {
+                support_changed();
+            }
+
+            update_registration();
+        }
+
+        private bool name_has_owner(string name) {
+            if (bus == null) {
+                return false;
+            }
+
+            try {
+                Variant result = bus.call_sync(
+                    DBUS_BUS_NAME,
+                    DBUS_OBJECT_PATH,
+                    DBUS_IFACE,
+                    "NameHasOwner",
+                    new Variant("(s)", name),
+                    new VariantType("(b)"),
+                    DBusCallFlags.NONE,
+                    -1
+                );
+                return result.get_child_value(0).get_boolean();
+            } catch (Error error) {
+                debug("Unable to check status indicator support: %s", error.message);
+                return false;
+            }
+        }
+
+        private void update_registration() {
+            if (!enabled || !supported || bus == null) {
+                unregister_item();
+                return;
+            }
+
+            register_item();
+        }
+
+        private void register_item() {
+            if (item_registration_id != 0) {
+                register_with_watcher();
+                return;
+            }
+
+            item = new StatusNotifierItem();
+            item.activated.connect(() => activated());
+
+            try {
+                item_registration_id = bus.register_object(ITEM_OBJECT_PATH, item);
+            } catch (IOError error) {
+                warning("Unable to export status indicator: %s", error.message);
+                item = null;
+                item_registration_id = 0;
+                return;
+            }
+
+            register_with_watcher();
+        }
+
+        private void register_with_watcher() {
+            try {
+                bus.call_sync(
+                    WATCHER_BUS_NAME,
+                    WATCHER_OBJECT_PATH,
+                    WATCHER_IFACE,
+                    "RegisterStatusNotifierItem",
+                    new Variant("(s)", bus.get_unique_name()),
+                    null,
+                    DBusCallFlags.NONE,
+                    -1
+                );
+            } catch (Error error) {
+                debug("Unable to register status indicator with watcher: %s", error.message);
+            }
+        }
+
+        private void unregister_item() {
+            if (bus != null && item_registration_id != 0) {
+                bus.unregister_object(item_registration_id);
+                item_registration_id = 0;
+            }
+
+            item = null;
+        }
+
+        private static bool is_flatpak() {
+            return FileUtils.test("/.flatpak-info", FileTest.EXISTS);
+        }
+    }
+}

--- a/src/status-indicator.vala
+++ b/src/status-indicator.vala
@@ -7,6 +7,7 @@ namespace MprisMiniPlayer {
     [DBus (name = "org.kde.StatusNotifierItem")]
     public class StatusNotifierItem : Object {
         private const string APP_ID = "io.github.ChrisLauinger.MprisMiniPlayer";
+        private const string MENU_OBJECT_PATH = "/StatusNotifierMenu";
 
         public signal void activated();
 
@@ -61,7 +62,7 @@ namespace MprisMiniPlayer {
         [DBus (name = "Menu")]
         public ObjectPath menu {
             owned get {
-                return new ObjectPath("/");
+                return new ObjectPath(MENU_OBJECT_PATH);
             }
         }
 
@@ -100,7 +101,6 @@ namespace MprisMiniPlayer {
 
         [DBus (name = "ContextMenu")]
         public void context_menu(int x, int y) throws DBusError, IOError {
-            activated();
         }
 
         [DBus (name = "SecondaryActivate")]
@@ -113,6 +113,203 @@ namespace MprisMiniPlayer {
         }
     }
 
+    [DBus (name = "com.canonical.dbusmenu")]
+    public class StatusNotifierMenu : Object {
+        private const int ROOT_ID = 0;
+        private const int SHOW_HIDE_ID = 1;
+        private const int PREFERENCES_ID = 2;
+        private const int ABOUT_ID = 3;
+        private const int QUIT_ID = 4;
+
+        private uint revision = 1;
+        private bool window_visible = false;
+
+        public signal void action_requested(string action);
+
+        [DBus (name = "ItemsPropertiesUpdated")]
+        public signal void items_properties_updated(Variant updated_props, Variant removed_props);
+
+        [DBus (name = "LayoutUpdated")]
+        public signal void layout_updated(uint revision, int parent);
+
+        [DBus (name = "ItemActivationRequested")]
+        public signal void item_activation_requested(int id, uint timestamp);
+
+        [DBus (name = "Version")]
+        public uint version {
+            get {
+                return 3;
+            }
+        }
+
+        [DBus (name = "TextDirection")]
+        public string text_direction {
+            owned get {
+                return "ltr";
+            }
+        }
+
+        [DBus (name = "Status")]
+        public string status {
+            owned get {
+                return "normal";
+            }
+        }
+
+        [DBus (name = "IconThemePath")]
+        public string[] icon_theme_path {
+            owned get {
+                return {};
+            }
+        }
+
+        [DBus (visible = false)]
+        public void set_window_visible(bool visible) {
+            if (window_visible == visible) {
+                return;
+            }
+
+            window_visible = visible;
+            revision++;
+            layout_updated(revision, ROOT_ID);
+        }
+
+        [DBus (name = "GetLayout")]
+        public void get_layout(
+            int parent_id,
+            int recursion_depth,
+            string[] property_names,
+            out uint revision,
+            [DBus (signature = "(ia{sv}av)")]
+            out Variant layout
+        ) throws DBusError, IOError {
+            revision = this.revision;
+            layout = build_layout();
+        }
+
+        [DBus (name = "GetGroupProperties", signature = "a(ia{sv})")]
+        public Variant get_group_properties(int[] ids, string[] property_names) throws DBusError, IOError {
+            var items = new VariantBuilder(new VariantType("a(ia{sv})"));
+            int[] requested_ids = ids.length == 0
+                ? new int[] { SHOW_HIDE_ID, PREFERENCES_ID, ABOUT_ID, QUIT_ID }
+                : ids;
+
+            foreach (int id in requested_ids) {
+                if (id == ROOT_ID || id == SHOW_HIDE_ID || id == PREFERENCES_ID || id == ABOUT_ID || id == QUIT_ID) {
+                    items.add_value(new Variant.tuple({
+                        new Variant.int32(id),
+                        build_properties(id)
+                    }));
+                }
+            }
+
+            return items.end();
+        }
+
+        [DBus (name = "GetProperty")]
+        public new Variant get_property(int id, string name) throws DBusError, IOError {
+            Variant? value = build_properties(id).lookup_value(name, null);
+            if (value != null) {
+                return value;
+            }
+
+            return new Variant.string("");
+        }
+
+        [DBus (name = "Event")]
+        public void event(int id, string event_id, Variant data, uint timestamp) throws DBusError, IOError {
+            if (event_id == "clicked") {
+                activate_item(id, timestamp);
+            }
+        }
+
+        [DBus (name = "AboutToShow")]
+        public bool about_to_show(int id) throws DBusError, IOError {
+            return false;
+        }
+
+        [DBus (name = "AboutToShowGroup")]
+        public void about_to_show_group(
+            int[] ids,
+            out int[] updates_needed,
+            out int[] id_errors
+        ) throws DBusError, IOError {
+            updates_needed = {};
+            id_errors = {};
+        }
+
+        private Variant build_layout() {
+            var children = new VariantBuilder(new VariantType("av"));
+            children.add_value(new Variant.variant(build_item(SHOW_HIDE_ID)));
+            children.add_value(new Variant.variant(build_item(PREFERENCES_ID)));
+            children.add_value(new Variant.variant(build_item(ABOUT_ID)));
+            children.add_value(new Variant.variant(build_item(QUIT_ID)));
+
+            var root_properties = new VariantBuilder(new VariantType("a{sv}"));
+            root_properties.add("{sv}", "children-display", new Variant.string("submenu"));
+
+            return new Variant.tuple({
+                new Variant.int32(ROOT_ID),
+                root_properties.end(),
+                children.end()
+            });
+        }
+
+        private Variant build_item(int id) {
+            var children = new VariantBuilder(new VariantType("av"));
+            return new Variant.tuple({
+                new Variant.int32(id),
+                build_properties(id),
+                children.end()
+            });
+        }
+
+        private Variant build_properties(int id) {
+            var properties = new VariantBuilder(new VariantType("a{sv}"));
+            properties.add("{sv}", "enabled", new Variant.boolean(true));
+            properties.add("{sv}", "visible", new Variant.boolean(true));
+            properties.add("{sv}", "type", new Variant.string("standard"));
+            properties.add("{sv}", "label", new Variant.string(get_label(id)));
+            return properties.end();
+        }
+
+        private string get_label(int id) {
+            switch (id) {
+                case SHOW_HIDE_ID:
+                    return window_visible ? _("Hide") : _("Show");
+                case PREFERENCES_ID:
+                    return _("Preferences");
+                case ABOUT_ID:
+                    return _("About");
+                case QUIT_ID:
+                    return _("Quit");
+                default:
+                    return "";
+            }
+        }
+
+        private void activate_item(int id, uint timestamp) {
+            switch (id) {
+                case SHOW_HIDE_ID:
+                    action_requested(window_visible ? "hide" : "show");
+                    break;
+                case PREFERENCES_ID:
+                    action_requested("preferences");
+                    break;
+                case ABOUT_ID:
+                    action_requested("about");
+                    break;
+                case QUIT_ID:
+                    action_requested("quit");
+                    break;
+                default:
+                    return;
+            }
+
+            item_activation_requested(id, timestamp);
+        }
+    }
+
     public class StatusIndicator : Object {
         private const string WATCHER_BUS_NAME = "org.kde.StatusNotifierWatcher";
         private const string WATCHER_OBJECT_PATH = "/StatusNotifierWatcher";
@@ -121,17 +318,22 @@ namespace MprisMiniPlayer {
         private const string DBUS_OBJECT_PATH = "/org/freedesktop/DBus";
         private const string DBUS_IFACE = "org.freedesktop.DBus";
         private const string ITEM_OBJECT_PATH = "/StatusNotifierItem";
+        private const string MENU_OBJECT_PATH = "/StatusNotifierMenu";
 
         private DBusConnection? bus;
         private StatusNotifierItem? item;
+        private StatusNotifierMenu? menu;
         private uint item_registration_id = 0;
+        private uint menu_registration_id = 0;
         private uint name_owner_subscription_id = 0;
         private bool enabled = false;
+        private bool window_visible = false;
 
         public bool supported { get; private set; default = false; }
 
         public signal void support_changed();
         public signal void activated();
+        public signal void action_requested(string action);
 
         public StatusIndicator() {
             if (is_flatpak()) {
@@ -152,6 +354,14 @@ namespace MprisMiniPlayer {
         public void set_enabled(bool enabled) {
             this.enabled = enabled;
             update_registration();
+        }
+
+        public void set_window_visible(bool visible) {
+            window_visible = visible;
+
+            if (menu != null) {
+                menu.set_window_visible(visible);
+            }
         }
 
         public void shutdown() {
@@ -237,13 +447,16 @@ namespace MprisMiniPlayer {
 
             item = new StatusNotifierItem();
             item.activated.connect(() => activated());
+            menu = new StatusNotifierMenu();
+            menu.set_window_visible(window_visible);
+            menu.action_requested.connect((action) => action_requested(action));
 
             try {
+                menu_registration_id = bus.register_object(MENU_OBJECT_PATH, menu);
                 item_registration_id = bus.register_object(ITEM_OBJECT_PATH, item);
             } catch (IOError error) {
                 warning("Unable to export status indicator: %s", error.message);
-                item = null;
-                item_registration_id = 0;
+                unregister_item();
                 return;
             }
 
@@ -272,8 +485,13 @@ namespace MprisMiniPlayer {
                 bus.unregister_object(item_registration_id);
                 item_registration_id = 0;
             }
+            if (bus != null && menu_registration_id != 0) {
+                bus.unregister_object(menu_registration_id);
+                menu_registration_id = 0;
+            }
 
             item = null;
+            menu = null;
         }
 
         private static bool is_flatpak() {


### PR DESCRIPTION
Implements an optional native status indicator (StatusNotifierItem) for compatible desktops, enhancing background operation with quick access to application actions. This includes a context menu for show/hide, preferences, about, and quit, alongside a new preference to enable or disable the indicator.

**Review Focus:**
Review D-Bus integration for the StatusNotifierItem, the indicator's lifecycle management, and the proper interaction between indicator actions and application logic.

**Breaking Changes:**
None. 'About' and 'Quit' actions are now primarily accessible via the new status indicator menu, shifting from their previous location within the Preferences window.