### PR TITLE
Fix automatic window show and prepare 1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ sudo ninja -C build uninstall
 Pushing a version tag builds a Flatpak bundle, builds an amd64 Debian package, and creates a GitHub release:
 
 ```bash
-git tag v1.3.0
-git push origin v1.3.0
+git tag v1.3.1
+git push origin v1.3.1
 ```
 
 The release workflow attaches `MPRIS-MiniPlayer-<tag>-x86_64.flatpak` and `mpris-miniplayer_<tag>_amd64.deb` to the generated release.

--- a/data/io.github.ChrisLauinger.MprisMiniPlayer.releases.xml
+++ b/data/io.github.ChrisLauinger.MprisMiniPlayer.releases.xml
@@ -1,4 +1,9 @@
   <releases>
+    <release version="1.3.1" date="2026-07-08">
+      <description>
+        <p>Show the player window again when media becomes available without triggering an application-ready notification.</p>
+      </description>
+    </release>
     <release version="1.3.0" date="2026-07-04">
       <description>
         <p>Add an optional album artwork color tint for the player window.</p>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+mpris-miniplayer (1.3.1-1) unstable; urgency=medium
+
+  * Show the player window again when media becomes available without
+    triggering an application-ready notification.
+
+ -- Christian Lauinger <chrislauinger77@users.noreply.github.com>  Wed, 08 Jul 2026 19:31:09 +0200
+
 mpris-miniplayer (1.3.0-1) unstable; urgency=medium
 
   * Add an optional album artwork color tint for the player window.

--- a/debian/mpris-miniplayer.1
+++ b/debian/mpris-miniplayer.1
@@ -1,4 +1,4 @@
-.TH MPRIS-MINIPLAYER 1 "July 2026" "MPRIS MiniPlayer 1.3.0" "User Commands"
+.TH MPRIS-MINIPLAYER 1 "July 2026" "MPRIS MiniPlayer 1.3.1" "User Commands"
 .SH NAME
 mpris-miniplayer \- control MPRIS-compatible media players
 .SH SYNOPSIS

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'mpris-miniplayer',
   ['vala', 'c'],
-  version: '1.3.0',
+  version: '1.3.1',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59.0',
 )

--- a/src/application.vala
+++ b/src/application.vala
@@ -118,7 +118,7 @@ namespace MprisMiniPlayer {
             }
 
             if (players_available) {
-                present_window();
+                show_window_automatically();
             } else if (main_window != null) {
                 hide_window();
             }
@@ -135,6 +135,14 @@ namespace MprisMiniPlayer {
         }
 
         private void present_window() {
+            show_window(true);
+        }
+
+        private void show_window_automatically() {
+            show_window(false);
+        }
+
+        private void show_window(bool request_activation) {
             if (main_window == null) {
                 main_window = new Window(
                     this,
@@ -149,7 +157,14 @@ namespace MprisMiniPlayer {
             }
 
             main_window.refresh_players();
-            main_window.present();
+            if (request_activation) {
+                main_window.present();
+            } else {
+                // A player can appear without user interaction. Requesting focus in
+                // that case is rejected by Wayland compositors and may produce an
+                // "app is ready" notification instead of showing the window.
+                main_window.set_visible(true);
+            }
             background_portal.leave_background();
             withdraw_notification(BACKGROUND_NOTIFICATION_ID);
         }


### PR DESCRIPTION
## Summary

- show the mini-player again when an MPRIS player becomes available
- avoid requesting focus for automatic, non-user-initiated window visibility
- prepare project, AppStream, Debian, manpage, and README metadata for version 1.3.1

## Why

After the active media player disappeared, MPRIS MiniPlayer correctly hid itself. When a player later appeared, the app called `present()` from an unsolicited D-Bus event. GNOME's focus-stealing protection could reject that activation and display an application-ready notification instead of remapping the window.

Automatic visibility now uses `set_visible(true)`, while explicit user actions continue to use `present()` so they still focus and raise the window normally.

## Validation

- `meson compile -C build`
- `msgfmt --check` for every PO catalog
- `desktop-file-validate build/data/io.github.ChrisLauinger.MprisMiniPlayer.desktop`
- `appstreamcli validate --no-net build/data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml`
- `dpkg-parsechangelog -S Version` returns `1.3.1-1`
- `git diff --check`
