### PR TITLE
Add RPM packaging and prepare release 1.3.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,6 @@ jobs:
             gtk4-devel \
             libadwaita-devel \
             meson \
-            meson-rpm-macros \
             rpm-build \
             vala
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,6 @@
 name: Release
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/release.yml"
-      - "rpm/**"
   push:
     tags:
       - "v*"
@@ -15,7 +11,6 @@ permissions:
 jobs:
   flatpak:
     name: Build Flatpak
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
@@ -43,7 +38,6 @@ jobs:
 
   debian:
     name: Build Debian package
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:
@@ -107,14 +101,7 @@ jobs:
       - name: Build x86_64 RPM package
         shell: bash
         run: |
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            version="${GITHUB_REF_NAME#v}"
-            asset_name="mpris-miniplayer-${GITHUB_REF_NAME}.x86_64.rpm"
-          else
-            version="$(rpmspec -q --queryformat '%{version}' rpm/mpris-miniplayer.spec)"
-            asset_name="mpris-miniplayer-${version}-test.x86_64.rpm"
-          fi
-          echo "RPM_ASSET_NAME=${asset_name}" >> "$GITHUB_ENV"
+          version="${GITHUB_REF_NAME#v}"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           mkdir -p "$HOME/rpmbuild/SOURCES"
           git archive \
@@ -127,18 +114,17 @@ jobs:
             rpm/mpris-miniplayer.spec
           mkdir -p release-assets
           cp "$HOME"/rpmbuild/RPMS/x86_64/mpris-miniplayer-"${version}"-*.x86_64.rpm \
-            "release-assets/${asset_name}"
+            "release-assets/mpris-miniplayer-${GITHUB_REF_NAME}.x86_64.rpm"
 
       - name: Upload RPM package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: rpm-package
-          path: release-assets/${{ env.RPM_ASSET_NAME }}
+          path: release-assets/mpris-miniplayer-${{ github.ref_name }}.x86_64.rpm
           if-no-files-found: error
 
   release:
     name: Create GitHub release
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
       - flatpak

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
             --define "pkg_version ${version}" \
             rpm/mpris-miniplayer.spec
           mkdir -p release-assets
-          cp "$HOME"/rpmbuild/RPMS/x86_64/mpris-miniplayer-*.x86_64.rpm \
+          cp "$HOME"/rpmbuild/RPMS/x86_64/mpris-miniplayer-"${version}"-*.x86_64.rpm \
             "release-assets/${asset_name}"
 
       - name: Upload RPM package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,12 +75,61 @@ jobs:
           path: release-assets/mpris-miniplayer_${{ github.ref_name }}_amd64.deb
           if-no-files-found: error
 
+  rpm:
+    name: Build RPM package
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+
+    steps:
+      - name: Install build dependencies
+        run: |
+          dnf install -y \
+            desktop-file-utils \
+            gcc \
+            gettext \
+            git \
+            gtk4-devel \
+            libadwaita-devel \
+            meson \
+            meson-rpm-macros \
+            rpm-build \
+            vala
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Build x86_64 RPM package
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          mkdir -p "$HOME/rpmbuild/SOURCES"
+          git archive \
+            --format=tar.gz \
+            --prefix="mpris-miniplayer-${version}/" \
+            --output="$HOME/rpmbuild/SOURCES/mpris-miniplayer-${version}.tar.gz" \
+            HEAD
+          rpmbuild -bb \
+            --define "pkg_version ${version}" \
+            rpm/mpris-miniplayer.spec
+          mkdir -p release-assets
+          cp "$HOME"/rpmbuild/RPMS/x86_64/mpris-miniplayer-*.x86_64.rpm \
+            "release-assets/mpris-miniplayer-${GITHUB_REF_NAME}.x86_64.rpm"
+
+      - name: Upload RPM package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: rpm-package
+          path: release-assets/mpris-miniplayer-${{ github.ref_name }}.x86_64.rpm
+          if-no-files-found: error
+
   release:
     name: Create GitHub release
     runs-on: ubuntu-latest
     needs:
       - flatpak
       - debian
+      - rpm
 
     steps:
       - name: Download release artifacts
@@ -94,5 +143,6 @@ jobs:
           files: |
             release-assets/flatpak-bundle/MPRIS-MiniPlayer-${{ github.ref_name }}-x86_64.flatpak
             release-assets/debian-package/mpris-miniplayer_${{ github.ref_name }}_amd64.deb
+            release-assets/rpm-package/mpris-miniplayer-${{ github.ref_name }}.x86_64.rpm
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,7 @@ jobs:
             asset_name="mpris-miniplayer-${version}-test.x86_64.rpm"
           fi
           echo "RPM_ASSET_NAME=${asset_name}" >> "$GITHUB_ENV"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           mkdir -p "$HOME/rpmbuild/SOURCES"
           git archive \
             --format=tar.gz \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: Release
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
+      - "rpm/**"
   push:
     tags:
       - "v*"
@@ -11,6 +15,7 @@ permissions:
 jobs:
   flatpak:
     name: Build Flatpak
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
@@ -38,6 +43,7 @@ jobs:
 
   debian:
     name: Build Debian package
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:
@@ -102,7 +108,14 @@ jobs:
       - name: Build x86_64 RPM package
         shell: bash
         run: |
-          version="${GITHUB_REF_NAME#v}"
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            version="${GITHUB_REF_NAME#v}"
+            asset_name="mpris-miniplayer-${GITHUB_REF_NAME}.x86_64.rpm"
+          else
+            version="$(rpmspec -q --queryformat '%{version}' rpm/mpris-miniplayer.spec)"
+            asset_name="mpris-miniplayer-${version}-test.x86_64.rpm"
+          fi
+          echo "RPM_ASSET_NAME=${asset_name}" >> "$GITHUB_ENV"
           mkdir -p "$HOME/rpmbuild/SOURCES"
           git archive \
             --format=tar.gz \
@@ -114,17 +127,18 @@ jobs:
             rpm/mpris-miniplayer.spec
           mkdir -p release-assets
           cp "$HOME"/rpmbuild/RPMS/x86_64/mpris-miniplayer-*.x86_64.rpm \
-            "release-assets/mpris-miniplayer-${GITHUB_REF_NAME}.x86_64.rpm"
+            "release-assets/${asset_name}"
 
       - name: Upload RPM package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: rpm-package
-          path: release-assets/mpris-miniplayer-${{ github.ref_name }}.x86_64.rpm
+          path: release-assets/${{ env.RPM_ASSET_NAME }}
           if-no-files-found: error
 
   release:
     name: Create GitHub release
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
       - flatpak

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,8 @@ mpris-miniplayer/
 │   ├── io.github.ChrisLauinger.MprisMiniPlayer.releases.xml
 │   └── meson.build
 ├── po/
+├── rpm/
+│   └── mpris-miniplayer.spec
 ├── src/
 │   ├── main.vala
 │   ├── application.vala
@@ -77,7 +79,7 @@ meson compile -C build mpris-miniplayer-pot
 meson compile -C build mpris-miniplayer-update-po
 msgattrib --untranslated --no-obsolete po/*.po
 msgattrib --only-fuzzy --no-obsolete po/*.po
-msgfmt --check po/*.po
+for po_file in po/*.po; do msgfmt --check "$po_file" -o /dev/null; done
 ```
 
 Keep `po/mpris-miniplayer.pot` up to date when adding, removing, or changing translatable strings. Check both untranslated and fuzzy entries before considering translation work complete.
@@ -105,6 +107,29 @@ sudo apt install \
 
 Package names may need adjustment by distribution and version.
 
+Typical Fedora dependencies for building the application and RPM package:
+
+```bash
+sudo dnf install \
+  desktop-file-utils gcc gettext git \
+  gtk4-devel libadwaita-devel meson meson-rpm-macros \
+  rpm-build vala
+```
+
+To reproduce the release RPM build locally, create the source archive expected by
+the spec and pass the upstream version without the tag's `v` prefix:
+
+```bash
+version="1.3.3"
+mkdir -p "$HOME/rpmbuild/SOURCES"
+git archive \
+  --format=tar.gz \
+  --prefix="mpris-miniplayer-${version}/" \
+  --output="$HOME/rpmbuild/SOURCES/mpris-miniplayer-${version}.tar.gz" \
+  HEAD
+rpmbuild -bb --define "pkg_version ${version}" rpm/mpris-miniplayer.spec
+```
+
 ## Release Version Checklist
 
 When preparing a new release, update the version in:
@@ -113,6 +138,7 @@ When preparing a new release, update the version in:
 - `data/io.github.ChrisLauinger.MprisMiniPlayer.releases.xml`: add a new top `<release>` entry with the new version and release date.
 - `debian/changelog`: add a new Debian changelog entry, usually `<upstream-version>-1` for a new upstream release.
 - `debian/mpris-miniplayer.1`: update the manpage header version string.
+- `rpm/mpris-miniplayer.spec`: update the fallback `pkg_version` and add a new top `%changelog` entry.
 
 Do not translate AppStream release notes. Keep release entries in `data/io.github.ChrisLauinger.MprisMiniPlayer.releases.xml`, which is intentionally not listed in `po/POTFILES`; release-note strings should never be added to `po/mpris-miniplayer.pot` or `po/*.po`.
 
@@ -123,7 +149,8 @@ git tag v1.1.0
 git push origin v1.1.0
 ```
 
-The release workflow uses the Git tag for the uploaded Flatpak and Debian package asset names.
+The release workflow removes the tag's `v` prefix for the RPM package metadata.
+It uses the full Git tag in the uploaded Flatpak, Debian, and RPM asset names.
 
 ## MPRIS Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ Typical Fedora dependencies for building the application and RPM package:
 ```bash
 sudo dnf install \
   desktop-file-utils gcc gettext git \
-  gtk4-devel libadwaita-devel meson meson-rpm-macros \
+  gtk4-devel libadwaita-devel meson \
   rpm-build vala
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ For Debian or Ubuntu on amd64, install the Debian package with:
 sudo apt install ./mpris-miniplayer_<version>_amd64.deb
 ```
 
+For Fedora on x86_64, install the RPM package with:
+
+```bash
+sudo dnf install ./mpris-miniplayer-<version>.x86_64.rpm
+```
+
 Run it from your application launcher, or from a terminal.
 
 For Flatpak:
@@ -97,14 +103,14 @@ sudo ninja -C build uninstall
 
 ## Maintainer Release
 
-Pushing a version tag builds a Flatpak bundle, builds an amd64 Debian package, and creates a GitHub release:
+Pushing a version tag builds a Flatpak bundle, an amd64 Debian package, an x86_64 RPM package, and creates a GitHub release:
 
 ```bash
-git tag v1.3.2
-git push origin v1.3.2
+git tag v1.3.3
+git push origin v1.3.3
 ```
 
-The release workflow attaches `MPRIS-MiniPlayer-<tag>-x86_64.flatpak` and `mpris-miniplayer_<tag>_amd64.deb` to the generated release.
+The release workflow attaches `MPRIS-MiniPlayer-<tag>-x86_64.flatpak`, `mpris-miniplayer_<tag>_amd64.deb`, and `mpris-miniplayer-<tag>.x86_64.rpm` to the generated release.
 
 ## License
 

--- a/data/io.github.ChrisLauinger.MprisMiniPlayer.releases.xml
+++ b/data/io.github.ChrisLauinger.MprisMiniPlayer.releases.xml
@@ -1,4 +1,9 @@
   <releases>
+    <release version="1.3.3" date="2026-07-18">
+      <description>
+        <p>Add an x86_64 RPM package to GitHub releases.</p>
+      </description>
+    </release>
     <release version="1.3.2" date="2026-07-13">
       <description>
         <p>Update the Flatpak runtime to GNOME 50 and pin release workflow actions to immutable commits.</p>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mpris-miniplayer (1.3.3-1) unstable; urgency=medium
+
+  * Add an x86_64 RPM package to GitHub releases.
+
+ -- Christian Lauinger <chrislauinger77@users.noreply.github.com>  Sat, 18 Jul 2026 09:42:47 +0200
+
 mpris-miniplayer (1.3.2-1) unstable; urgency=medium
 
   * Update the Flatpak runtime to GNOME 50.

--- a/debian/mpris-miniplayer.1
+++ b/debian/mpris-miniplayer.1
@@ -1,4 +1,4 @@
-.TH MPRIS-MINIPLAYER 1 "July 2026" "MPRIS MiniPlayer 1.3.2" "User Commands"
+.TH MPRIS-MINIPLAYER 1 "July 2026" "MPRIS MiniPlayer 1.3.3" "User Commands"
 .SH NAME
 mpris-miniplayer \- control MPRIS-compatible media players
 .SH SYNOPSIS

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'mpris-miniplayer',
   ['vala', 'c'],
-  version: '1.3.2',
+  version: '1.3.3',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59.0',
 )

--- a/rpm/mpris-miniplayer.spec
+++ b/rpm/mpris-miniplayer.spec
@@ -12,7 +12,6 @@ Source0:        %{name}-%{version}.tar.gz
 BuildRequires:  desktop-file-utils
 BuildRequires:  gettext
 BuildRequires:  meson
-BuildRequires:  meson-rpm-macros
 BuildRequires:  pkgconfig(gdk-pixbuf-2.0)
 BuildRequires:  pkgconfig(gio-2.0)
 BuildRequires:  pkgconfig(gtk4)

--- a/rpm/mpris-miniplayer.spec
+++ b/rpm/mpris-miniplayer.spec
@@ -1,0 +1,51 @@
+%{!?pkg_version:%global pkg_version 1.3.3}
+
+Name:           mpris-miniplayer
+Version:        %{pkg_version}
+Release:        1%{?dist}
+Summary:        Small MPRIS media player controller
+
+License:        GPL-3.0-or-later
+URL:            https://github.com/ChrisLauinger77/mpris-miniplayer
+Source0:        %{name}-%{version}.tar.gz
+
+BuildRequires:  desktop-file-utils
+BuildRequires:  gettext
+BuildRequires:  meson
+BuildRequires:  meson-rpm-macros
+BuildRequires:  pkgconfig(gdk-pixbuf-2.0)
+BuildRequires:  pkgconfig(gio-2.0)
+BuildRequires:  pkgconfig(gtk4)
+BuildRequires:  pkgconfig(libadwaita-1) >= 1.5
+BuildRequires:  vala
+
+%description
+MPRIS MiniPlayer is a compact GTK4 and libadwaita controller for Linux media
+players that expose the MPRIS interface on the session D-Bus.
+
+%prep
+%autosetup
+
+%build
+%meson
+%meson_build
+
+%install
+%meson_install
+%find_lang %{name}
+
+%check
+desktop-file-validate %{buildroot}%{_datadir}/applications/io.github.ChrisLauinger.MprisMiniPlayer.desktop
+
+%files -f %{name}.lang
+%license LICENSE
+%doc README.md
+%{_bindir}/mpris-miniplayer
+%{_datadir}/applications/io.github.ChrisLauinger.MprisMiniPlayer.desktop
+%{_datadir}/glib-2.0/schemas/io.github.ChrisLauinger.MprisMiniPlayer.gschema.xml
+%{_datadir}/icons/hicolor/scalable/apps/io.github.ChrisLauinger.MprisMiniPlayer.svg
+%{_datadir}/metainfo/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml
+
+%changelog
+* Sat Jul 18 2026 Christian Lauinger <chrislauinger77@users.noreply.github.com> - 1.3.3-1
+- Add RPM packaging


### PR DESCRIPTION
## Summary

- build and publish an x86_64 RPM package from the release workflow
- add a Fedora RPM spec and document local RPM builds and installation
- prepare the project, AppStream, Debian, RPM, and documentation versions for 1.3.3

## Impact

Fedora users can install a native RPM asset from GitHub releases. Pushing the
`v1.3.3` tag will build Flatpak, Debian, and RPM artifacts before creating the
release.

## Validation

- Meson build succeeds
- desktop file validation succeeds
- AppStream validation succeeds
- all translation catalogs pass `msgfmt --check`
- `dpkg-buildpackage -us -uc -b` produces `mpris-miniplayer_1.3.3-1_amd64.deb`
- `git diff --check` passes

The RPM job itself will be exercised by GitHub Actions in its Fedora container.
