### PR TITLE
Add media controls to the status notifier

### DIFF
--- a/data/io.github.ChrisLauinger.MprisMiniPlayer.releases.xml
+++ b/data/io.github.ChrisLauinger.MprisMiniPlayer.releases.xml
@@ -1,4 +1,11 @@
   <releases>
+    <release version="1.4.0" date="2026-08-15">
+      <description>
+        <p>Show current track information and media controls in the status indicator menu.</p>
+        <p>Adjust player volume by scrolling over the status indicator, with temporary volume icon feedback.</p>
+        <p>Keep the status indicator and player window synchronized on the selected media player.</p>
+      </description>
+    </release>
     <release version="1.3.3" date="2026-07-18">
       <description>
         <p>Add an x86_64 RPM package to GitHub releases.</p>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+mpris-miniplayer (1.4.0-1) unstable; urgency=medium
+
+  * Show current track information and media controls in the status indicator
+    menu.
+  * Add mouse-wheel volume adjustment with temporary volume icon feedback.
+  * Synchronize the selected media player between the window and status
+    indicator.
+  * Keep status indicator submenus open during playback position updates.
+
+ -- Christian Lauinger <chrislauinger77@users.noreply.github.com>  Sat, 15 Aug 2026 11:10:02 +0200
+
 mpris-miniplayer (1.3.3-1) unstable; urgency=medium
 
   * Add an x86_64 RPM package to GitHub releases.

--- a/debian/mpris-miniplayer.1
+++ b/debian/mpris-miniplayer.1
@@ -1,4 +1,4 @@
-.TH MPRIS-MINIPLAYER 1 "July 2026" "MPRIS MiniPlayer 1.3.3" "User Commands"
+.TH MPRIS-MINIPLAYER 1 "August 2026" "MPRIS MiniPlayer 1.4.0" "User Commands"
 .SH NAME
 mpris-miniplayer \- control MPRIS-compatible media players
 .SH SYNOPSIS

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'mpris-miniplayer',
   ['vala', 'c'],
-  version: '1.3.3',
+  version: '1.4.0',
   license: 'GPL-3.0-or-later',
   meson_version: '>= 0.59.0',
 )

--- a/po/de.po
+++ b/po/de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mpris-miniplayer 0.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-04 10:21+0200\n"
+"POT-Creation-Date: 2026-08-15 10:41+0200\n"
 "PO-Revision-Date: 2026-06-21 09:39+0200\n"
 "Last-Translator: Christian Lauinger\n"
 "Language-Team: German\n"
@@ -14,7 +14,7 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in:2
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:6
-#: src/status-indicator.vala:37 src/application.vala:184 src/window.vala:47
+#: src/status-indicator.vala:38 src/application.vala:208 src/window.vala:46
 msgid "MPRIS MiniPlayer"
 msgstr "MPRIS MiniPlayer"
 
@@ -43,36 +43,69 @@ msgstr "Medienspieler überwachen"
 msgid "Keep watching for MPRIS-compatible media players"
 msgstr "Weiter nach MPRIS-kompatiblen Medienspielern suchen"
 
-#: src/status-indicator.vala:287
+#: src/status-indicator.vala:390
 msgid "Show"
 msgstr "Anzeigen"
 
-#: src/status-indicator.vala:289
+#: src/status-indicator.vala:392
 msgid "Hide"
 msgstr "Ausblenden"
 
-#: src/status-indicator.vala:291 src/window.vala:131
+#: src/status-indicator.vala:400 src/window.vala:288
+msgid "No player detected"
+msgstr "Kein Medienspieler erkannt"
+
+#: src/status-indicator.vala:402 src/window.vala:240
+msgid "Previous"
+msgstr "Zurück"
+
+#: src/status-indicator.vala:405
+msgid "Pause"
+msgstr "Pause"
+
+#: src/status-indicator.vala:406
+msgid "Play"
+msgstr "Wiedergabe"
+
+#: src/status-indicator.vala:408 src/window.vala:259
+msgid "Next"
+msgstr "Weiter"
+
+#: src/status-indicator.vala:410
+#, c-format
+msgid "Volume: %d%%"
+msgstr "Lautstärke: %d%%"
+
+#: src/status-indicator.vala:413 src/window.vala:636
+msgid "Mute"
+msgstr "Stummschalten"
+
+#: src/status-indicator.vala:414 src/window.vala:632
+msgid "Restore volume"
+msgstr "Lautstärke wiederherstellen"
+
+#: src/status-indicator.vala:424 src/window.vala:136
 msgid "Compact Mode"
 msgstr "Kompakter Modus"
 
-#: src/status-indicator.vala:293 src/preferences-window.vala:15
-#: src/preferences-window.vala:32 src/window.vala:132
+#: src/status-indicator.vala:426 src/preferences-window.vala:15
+#: src/preferences-window.vala:32 src/window.vala:137
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: src/status-indicator.vala:295
+#: src/status-indicator.vala:428
 msgid "About"
 msgstr "Info"
 
-#: src/status-indicator.vala:297 src/window.vala:133
+#: src/status-indicator.vala:430 src/window.vala:138
 msgid "Quit"
 msgstr "Beenden"
 
-#: src/application.vala:260
+#: src/application.vala:334
 msgid "MPRIS MiniPlayer is running in the background"
 msgstr "MPRIS MiniPlayer läuft im Hintergrund"
 
-#: src/application.vala:262
+#: src/application.vala:336
 msgid ""
 "The window will appear automatically when a compatible media player becomes "
 "available."
@@ -80,12 +113,12 @@ msgstr ""
 "Das Fenster erscheint automatisch, sobald ein kompatibler Medienspieler "
 "verfügbar ist."
 
-#: src/application.vala:264
+#: src/application.vala:338
 msgid "Open the window when you want to control a compatible media player."
 msgstr ""
 "Öffne das Fenster, wenn du einen kompatiblen Medienspieler steuern möchtest."
 
-#: src/application.vala:266
+#: src/application.vala:340
 msgid "Open"
 msgstr "Öffnen"
 
@@ -147,77 +180,61 @@ msgstr "Eine Anzeige zeigen, wenn die Anwendung läuft"
 msgid "Not supported by this desktop"
 msgstr "Von diesem Desktop nicht unterstützt"
 
-#: src/window.vala:124
+#: src/window.vala:129
 msgid "Choose player"
 msgstr "Medienspieler auswählen"
 
-#: src/window.vala:137
+#: src/window.vala:142
 msgid "Main menu"
 msgstr "Hauptmenü"
 
-#: src/window.vala:142
+#: src/window.vala:147
 msgid "About MPRIS MiniPlayer"
 msgstr "Info zu MPRIS MiniPlayer"
 
-#: src/window.vala:171
+#: src/window.vala:176
 msgid "No player running"
 msgstr "Kein Medienspieler läuft"
 
-#: src/window.vala:177
+#: src/window.vala:182
 msgid "Start an MPRIS-compatible media player"
 msgstr "Starte einen MPRIS-kompatiblen Medienspieler"
 
-#: src/window.vala:218 src/window.vala:229
+#: src/window.vala:223 src/window.vala:234
 msgid "Volume"
 msgstr "Lautstärke"
 
-#: src/window.vala:235
-msgid "Previous"
-msgstr "Zurück"
-
-#: src/window.vala:244
+#: src/window.vala:249
 msgid "Play or pause"
 msgstr "Wiedergabe oder Pause"
 
-#: src/window.vala:254
-msgid "Next"
-msgstr "Weiter"
-
-#: src/window.vala:275
+#: src/window.vala:279
 msgid "Session D-Bus unavailable"
 msgstr "Sitzungs-D-Bus nicht verfügbar"
 
-#: src/window.vala:275
+#: src/window.vala:279 src/window.vala:294
 msgid "Unable to monitor MPRIS players"
 msgstr "MPRIS-Medienspieler können nicht überwacht werden"
 
-#: src/window.vala:285
-msgid "No player detected"
-msgstr "Kein Medienspieler erkannt"
-
-#: src/window.vala:285
+#: src/window.vala:288
 msgid "Start any MPRIS-compatible player"
 msgstr "Starte einen MPRIS-kompatiblen Medienspieler"
 
-#: src/window.vala:315
+#: src/window.vala:294
 msgid "Player unavailable"
 msgstr "Medienspieler nicht verfügbar"
 
-#: src/window.vala:667
-msgid "Restore volume"
-msgstr "Lautstärke wiederherstellen"
-
-#: src/window.vala:671
-msgid "Mute"
-msgstr "Stummschalten"
-
-#: src/mpris-player.vala:240
+#: src/mpris-player.vala:268
 msgid "Unknown track"
 msgstr "Unbekannter Titel"
 
-#: src/mpris-player.vala:247
+#: src/mpris-player.vala:275
 msgid "Unknown artist"
 msgstr "Unbekannter Künstler"
+
+#, fuzzy
+#~ msgid "Unable to connect to the selected player"
+#~ msgstr "MPRIS-Medienspieler können nicht überwacht werden"
 
 #~ msgid "Application"
 #~ msgstr "Anwendung"

--- a/po/es.po
+++ b/po/es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mpris-miniplayer 0.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-04 10:21+0200\n"
+"POT-Creation-Date: 2026-08-15 10:41+0200\n"
 "PO-Revision-Date: 2026-06-21 09:39+0200\n"
 "Last-Translator: Christian Lauinger\n"
 "Language-Team: Spanish\n"
@@ -14,7 +14,7 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in:2
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:6
-#: src/status-indicator.vala:37 src/application.vala:184 src/window.vala:47
+#: src/status-indicator.vala:38 src/application.vala:208 src/window.vala:46
 msgid "MPRIS MiniPlayer"
 msgstr "MPRIS MiniPlayer"
 
@@ -43,36 +43,69 @@ msgstr "Supervisando reproductores multimedia"
 msgid "Keep watching for MPRIS-compatible media players"
 msgstr "Seguir buscando reproductores multimedia compatibles con MPRIS"
 
-#: src/status-indicator.vala:287
+#: src/status-indicator.vala:390
 msgid "Show"
 msgstr "Mostrar"
 
-#: src/status-indicator.vala:289
+#: src/status-indicator.vala:392
 msgid "Hide"
 msgstr "Ocultar"
 
-#: src/status-indicator.vala:291 src/window.vala:131
+#: src/status-indicator.vala:400 src/window.vala:288
+msgid "No player detected"
+msgstr "No se detectó ningún reproductor"
+
+#: src/status-indicator.vala:402 src/window.vala:240
+msgid "Previous"
+msgstr "Anterior"
+
+#: src/status-indicator.vala:405
+msgid "Pause"
+msgstr "Pausa"
+
+#: src/status-indicator.vala:406
+msgid "Play"
+msgstr "Reproducir"
+
+#: src/status-indicator.vala:408 src/window.vala:259
+msgid "Next"
+msgstr "Siguiente"
+
+#: src/status-indicator.vala:410
+#, c-format
+msgid "Volume: %d%%"
+msgstr "Volumen: %d%%"
+
+#: src/status-indicator.vala:413 src/window.vala:636
+msgid "Mute"
+msgstr "Silenciar"
+
+#: src/status-indicator.vala:414 src/window.vala:632
+msgid "Restore volume"
+msgstr "Restaurar volumen"
+
+#: src/status-indicator.vala:424 src/window.vala:136
 msgid "Compact Mode"
 msgstr "Modo compacto"
 
-#: src/status-indicator.vala:293 src/preferences-window.vala:15
-#: src/preferences-window.vala:32 src/window.vala:132
+#: src/status-indicator.vala:426 src/preferences-window.vala:15
+#: src/preferences-window.vala:32 src/window.vala:137
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: src/status-indicator.vala:295
+#: src/status-indicator.vala:428
 msgid "About"
 msgstr "Acerca de"
 
-#: src/status-indicator.vala:297 src/window.vala:133
+#: src/status-indicator.vala:430 src/window.vala:138
 msgid "Quit"
 msgstr "Salir"
 
-#: src/application.vala:260
+#: src/application.vala:334
 msgid "MPRIS MiniPlayer is running in the background"
 msgstr "MPRIS MiniPlayer se está ejecutando en segundo plano"
 
-#: src/application.vala:262
+#: src/application.vala:336
 msgid ""
 "The window will appear automatically when a compatible media player becomes "
 "available."
@@ -80,13 +113,13 @@ msgstr ""
 "La ventana aparecerá automáticamente cuando haya disponible un reproductor "
 "multimedia compatible."
 
-#: src/application.vala:264
+#: src/application.vala:338
 msgid "Open the window when you want to control a compatible media player."
 msgstr ""
 "Abre la ventana cuando quieras controlar un reproductor multimedia "
 "compatible."
 
-#: src/application.vala:266
+#: src/application.vala:340
 msgid "Open"
 msgstr "Abrir"
 
@@ -148,77 +181,61 @@ msgstr "Mostrar un indicador cuando la aplicación esté en ejecución"
 msgid "Not supported by this desktop"
 msgstr "No compatible con este escritorio"
 
-#: src/window.vala:124
+#: src/window.vala:129
 msgid "Choose player"
 msgstr "Elegir reproductor"
 
-#: src/window.vala:137
+#: src/window.vala:142
 msgid "Main menu"
 msgstr "Menú principal"
 
-#: src/window.vala:142
+#: src/window.vala:147
 msgid "About MPRIS MiniPlayer"
 msgstr "Acerca de MPRIS MiniPlayer"
 
-#: src/window.vala:171
+#: src/window.vala:176
 msgid "No player running"
 msgstr "No hay ningún reproductor en ejecución"
 
-#: src/window.vala:177
+#: src/window.vala:182
 msgid "Start an MPRIS-compatible media player"
 msgstr "Inicia un reproductor multimedia compatible con MPRIS"
 
-#: src/window.vala:218 src/window.vala:229
+#: src/window.vala:223 src/window.vala:234
 msgid "Volume"
 msgstr "Volumen"
 
-#: src/window.vala:235
-msgid "Previous"
-msgstr "Anterior"
-
-#: src/window.vala:244
+#: src/window.vala:249
 msgid "Play or pause"
 msgstr "Reproducir o pausar"
 
-#: src/window.vala:254
-msgid "Next"
-msgstr "Siguiente"
-
-#: src/window.vala:275
+#: src/window.vala:279
 msgid "Session D-Bus unavailable"
 msgstr "D-Bus de sesión no disponible"
 
-#: src/window.vala:275
+#: src/window.vala:279 src/window.vala:294
 msgid "Unable to monitor MPRIS players"
 msgstr "No se pueden supervisar los reproductores MPRIS"
 
-#: src/window.vala:285
-msgid "No player detected"
-msgstr "No se detectó ningún reproductor"
-
-#: src/window.vala:285
+#: src/window.vala:288
 msgid "Start any MPRIS-compatible player"
 msgstr "Inicia cualquier reproductor compatible con MPRIS"
 
-#: src/window.vala:315
+#: src/window.vala:294
 msgid "Player unavailable"
 msgstr "Reproductor no disponible"
 
-#: src/window.vala:667
-msgid "Restore volume"
-msgstr "Restaurar volumen"
-
-#: src/window.vala:671
-msgid "Mute"
-msgstr "Silenciar"
-
-#: src/mpris-player.vala:240
+#: src/mpris-player.vala:268
 msgid "Unknown track"
 msgstr "Pista desconocida"
 
-#: src/mpris-player.vala:247
+#: src/mpris-player.vala:275
 msgid "Unknown artist"
 msgstr "Artista desconocido"
+
+#, fuzzy
+#~ msgid "Unable to connect to the selected player"
+#~ msgstr "No se pueden supervisar los reproductores MPRIS"
 
 #~ msgid "Application"
 #~ msgstr "Aplicación"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mpris-miniplayer 0.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-04 10:21+0200\n"
+"POT-Creation-Date: 2026-08-15 10:41+0200\n"
 "PO-Revision-Date: 2026-06-21 09:39+0200\n"
 "Last-Translator: Christian Lauinger\n"
 "Language-Team: French\n"
@@ -14,7 +14,7 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in:2
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:6
-#: src/status-indicator.vala:37 src/application.vala:184 src/window.vala:47
+#: src/status-indicator.vala:38 src/application.vala:208 src/window.vala:46
 msgid "MPRIS MiniPlayer"
 msgstr "MPRIS MiniPlayer"
 
@@ -43,36 +43,69 @@ msgstr "Surveillance des lecteurs multimédias"
 msgid "Keep watching for MPRIS-compatible media players"
 msgstr "Continuer à surveiller les lecteurs multimédias compatibles MPRIS"
 
-#: src/status-indicator.vala:287
+#: src/status-indicator.vala:390
 msgid "Show"
 msgstr "Afficher"
 
-#: src/status-indicator.vala:289
+#: src/status-indicator.vala:392
 msgid "Hide"
 msgstr "Masquer"
 
-#: src/status-indicator.vala:291 src/window.vala:131
+#: src/status-indicator.vala:400 src/window.vala:288
+msgid "No player detected"
+msgstr "Aucun lecteur détecté"
+
+#: src/status-indicator.vala:402 src/window.vala:240
+msgid "Previous"
+msgstr "Précédent"
+
+#: src/status-indicator.vala:405
+msgid "Pause"
+msgstr "Pause"
+
+#: src/status-indicator.vala:406
+msgid "Play"
+msgstr "Lecture"
+
+#: src/status-indicator.vala:408 src/window.vala:259
+msgid "Next"
+msgstr "Suivant"
+
+#: src/status-indicator.vala:410
+#, c-format
+msgid "Volume: %d%%"
+msgstr "Volume : %d %%"
+
+#: src/status-indicator.vala:413 src/window.vala:636
+msgid "Mute"
+msgstr "Couper le son"
+
+#: src/status-indicator.vala:414 src/window.vala:632
+msgid "Restore volume"
+msgstr "Restaurer le volume"
+
+#: src/status-indicator.vala:424 src/window.vala:136
 msgid "Compact Mode"
 msgstr "Mode compact"
 
-#: src/status-indicator.vala:293 src/preferences-window.vala:15
-#: src/preferences-window.vala:32 src/window.vala:132
+#: src/status-indicator.vala:426 src/preferences-window.vala:15
+#: src/preferences-window.vala:32 src/window.vala:137
 msgid "Preferences"
 msgstr "Préférences"
 
-#: src/status-indicator.vala:295
+#: src/status-indicator.vala:428
 msgid "About"
 msgstr "À propos"
 
-#: src/status-indicator.vala:297 src/window.vala:133
+#: src/status-indicator.vala:430 src/window.vala:138
 msgid "Quit"
 msgstr "Quitter"
 
-#: src/application.vala:260
+#: src/application.vala:334
 msgid "MPRIS MiniPlayer is running in the background"
 msgstr "MPRIS MiniPlayer s’exécute en arrière-plan"
 
-#: src/application.vala:262
+#: src/application.vala:336
 msgid ""
 "The window will appear automatically when a compatible media player becomes "
 "available."
@@ -80,13 +113,13 @@ msgstr ""
 "La fenêtre apparaîtra automatiquement lorsqu’un lecteur multimédia "
 "compatible sera disponible."
 
-#: src/application.vala:264
+#: src/application.vala:338
 msgid "Open the window when you want to control a compatible media player."
 msgstr ""
 "Ouvrez la fenêtre lorsque vous souhaitez contrôler un lecteur multimédia "
 "compatible."
 
-#: src/application.vala:266
+#: src/application.vala:340
 msgid "Open"
 msgstr "Ouvrir"
 
@@ -148,77 +181,61 @@ msgstr "Afficher un indicateur lorsque l’application est en cours d’exécuti
 msgid "Not supported by this desktop"
 msgstr "Non pris en charge par ce bureau"
 
-#: src/window.vala:124
+#: src/window.vala:129
 msgid "Choose player"
 msgstr "Choisir un lecteur"
 
-#: src/window.vala:137
+#: src/window.vala:142
 msgid "Main menu"
 msgstr "Menu principal"
 
-#: src/window.vala:142
+#: src/window.vala:147
 msgid "About MPRIS MiniPlayer"
 msgstr "À propos de MPRIS MiniPlayer"
 
-#: src/window.vala:171
+#: src/window.vala:176
 msgid "No player running"
 msgstr "Aucun lecteur en cours d’exécution"
 
-#: src/window.vala:177
+#: src/window.vala:182
 msgid "Start an MPRIS-compatible media player"
 msgstr "Lancez un lecteur multimédia compatible MPRIS"
 
-#: src/window.vala:218 src/window.vala:229
+#: src/window.vala:223 src/window.vala:234
 msgid "Volume"
 msgstr "Volume"
 
-#: src/window.vala:235
-msgid "Previous"
-msgstr "Précédent"
-
-#: src/window.vala:244
+#: src/window.vala:249
 msgid "Play or pause"
 msgstr "Lecture ou pause"
 
-#: src/window.vala:254
-msgid "Next"
-msgstr "Suivant"
-
-#: src/window.vala:275
+#: src/window.vala:279
 msgid "Session D-Bus unavailable"
 msgstr "D-Bus de session indisponible"
 
-#: src/window.vala:275
+#: src/window.vala:279 src/window.vala:294
 msgid "Unable to monitor MPRIS players"
 msgstr "Impossible de surveiller les lecteurs MPRIS"
 
-#: src/window.vala:285
-msgid "No player detected"
-msgstr "Aucun lecteur détecté"
-
-#: src/window.vala:285
+#: src/window.vala:288
 msgid "Start any MPRIS-compatible player"
 msgstr "Lancez un lecteur compatible MPRIS"
 
-#: src/window.vala:315
+#: src/window.vala:294
 msgid "Player unavailable"
 msgstr "Lecteur indisponible"
 
-#: src/window.vala:667
-msgid "Restore volume"
-msgstr "Restaurer le volume"
-
-#: src/window.vala:671
-msgid "Mute"
-msgstr "Couper le son"
-
-#: src/mpris-player.vala:240
+#: src/mpris-player.vala:268
 msgid "Unknown track"
 msgstr "Titre inconnu"
 
-#: src/mpris-player.vala:247
+#: src/mpris-player.vala:275
 msgid "Unknown artist"
 msgstr "Artiste inconnu"
+
+#, fuzzy
+#~ msgid "Unable to connect to the selected player"
+#~ msgstr "Impossible de surveiller les lecteurs MPRIS"
 
 #~ msgid "Application"
 #~ msgstr "Application"

--- a/po/mpris-miniplayer.pot
+++ b/po/mpris-miniplayer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mpris-miniplayer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-04 10:21+0200\n"
+"POT-Creation-Date: 2026-08-15 10:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in:2
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:6
-#: src/status-indicator.vala:37 src/application.vala:184 src/window.vala:47
+#: src/status-indicator.vala:38 src/application.vala:208 src/window.vala:46
 msgid "MPRIS MiniPlayer"
 msgstr ""
 
@@ -46,46 +46,79 @@ msgstr ""
 msgid "Keep watching for MPRIS-compatible media players"
 msgstr ""
 
-#: src/status-indicator.vala:287
+#: src/status-indicator.vala:390
 msgid "Show"
 msgstr ""
 
-#: src/status-indicator.vala:289
+#: src/status-indicator.vala:392
 msgid "Hide"
 msgstr ""
 
-#: src/status-indicator.vala:291 src/window.vala:131
+#: src/status-indicator.vala:400 src/window.vala:288
+msgid "No player detected"
+msgstr ""
+
+#: src/status-indicator.vala:402 src/window.vala:240
+msgid "Previous"
+msgstr ""
+
+#: src/status-indicator.vala:405
+msgid "Pause"
+msgstr ""
+
+#: src/status-indicator.vala:406
+msgid "Play"
+msgstr ""
+
+#: src/status-indicator.vala:408 src/window.vala:259
+msgid "Next"
+msgstr ""
+
+#: src/status-indicator.vala:410
+#, c-format
+msgid "Volume: %d%%"
+msgstr ""
+
+#: src/status-indicator.vala:413 src/window.vala:636
+msgid "Mute"
+msgstr ""
+
+#: src/status-indicator.vala:414 src/window.vala:632
+msgid "Restore volume"
+msgstr ""
+
+#: src/status-indicator.vala:424 src/window.vala:136
 msgid "Compact Mode"
 msgstr ""
 
-#: src/status-indicator.vala:293 src/preferences-window.vala:15
-#: src/preferences-window.vala:32 src/window.vala:132
+#: src/status-indicator.vala:426 src/preferences-window.vala:15
+#: src/preferences-window.vala:32 src/window.vala:137
 msgid "Preferences"
 msgstr ""
 
-#: src/status-indicator.vala:295
+#: src/status-indicator.vala:428
 msgid "About"
 msgstr ""
 
-#: src/status-indicator.vala:297 src/window.vala:133
+#: src/status-indicator.vala:430 src/window.vala:138
 msgid "Quit"
 msgstr ""
 
-#: src/application.vala:260
+#: src/application.vala:334
 msgid "MPRIS MiniPlayer is running in the background"
 msgstr ""
 
-#: src/application.vala:262
+#: src/application.vala:336
 msgid ""
 "The window will appear automatically when a compatible media player becomes "
 "available."
 msgstr ""
 
-#: src/application.vala:264
+#: src/application.vala:338
 msgid "Open the window when you want to control a compatible media player."
 msgstr ""
 
-#: src/application.vala:266
+#: src/application.vala:340
 msgid "Open"
 msgstr ""
 
@@ -145,74 +178,54 @@ msgstr ""
 msgid "Not supported by this desktop"
 msgstr ""
 
-#: src/window.vala:124
+#: src/window.vala:129
 msgid "Choose player"
 msgstr ""
 
-#: src/window.vala:137
+#: src/window.vala:142
 msgid "Main menu"
 msgstr ""
 
-#: src/window.vala:142
+#: src/window.vala:147
 msgid "About MPRIS MiniPlayer"
 msgstr ""
 
-#: src/window.vala:171
+#: src/window.vala:176
 msgid "No player running"
 msgstr ""
 
-#: src/window.vala:177
+#: src/window.vala:182
 msgid "Start an MPRIS-compatible media player"
 msgstr ""
 
-#: src/window.vala:218 src/window.vala:229
+#: src/window.vala:223 src/window.vala:234
 msgid "Volume"
 msgstr ""
 
-#: src/window.vala:235
-msgid "Previous"
-msgstr ""
-
-#: src/window.vala:244
+#: src/window.vala:249
 msgid "Play or pause"
 msgstr ""
 
-#: src/window.vala:254
-msgid "Next"
-msgstr ""
-
-#: src/window.vala:275
+#: src/window.vala:279
 msgid "Session D-Bus unavailable"
 msgstr ""
 
-#: src/window.vala:275
+#: src/window.vala:279 src/window.vala:294
 msgid "Unable to monitor MPRIS players"
 msgstr ""
 
-#: src/window.vala:285
-msgid "No player detected"
-msgstr ""
-
-#: src/window.vala:285
+#: src/window.vala:288
 msgid "Start any MPRIS-compatible player"
 msgstr ""
 
-#: src/window.vala:315
+#: src/window.vala:294
 msgid "Player unavailable"
 msgstr ""
 
-#: src/window.vala:667
-msgid "Restore volume"
-msgstr ""
-
-#: src/window.vala:671
-msgid "Mute"
-msgstr ""
-
-#: src/mpris-player.vala:240
+#: src/mpris-player.vala:268
 msgid "Unknown track"
 msgstr ""
 
-#: src/mpris-player.vala:247
+#: src/mpris-player.vala:275
 msgid "Unknown artist"
 msgstr ""

--- a/rpm/mpris-miniplayer.spec
+++ b/rpm/mpris-miniplayer.spec
@@ -1,4 +1,4 @@
-%{!?pkg_version:%global pkg_version 1.3.3}
+%{!?pkg_version:%global pkg_version 1.4.0}
 
 Name:           mpris-miniplayer
 Version:        %{pkg_version}
@@ -46,5 +46,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/io.github.ChrisLauing
 %{_datadir}/metainfo/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml
 
 %changelog
+* Sat Aug 15 2026 Christian Lauinger <chrislauinger77@users.noreply.github.com> - 1.4.0-1
+- Add track information and media controls to the status indicator
+- Add mouse-wheel volume adjustment with temporary icon feedback
+
 * Sat Jul 18 2026 Christian Lauinger <chrislauinger77@users.noreply.github.com> - 1.3.3-1
 - Add RPM packaging

--- a/src/application.vala
+++ b/src/application.vala
@@ -42,6 +42,8 @@ namespace MprisMiniPlayer {
                 manager = new MprisManager();
                 manager.players_changed.connect(on_players_changed);
                 manager.player_priority_changed.connect(on_player_priority_changed);
+                manager.active_player_changed.connect(on_active_player_changed);
+                status_indicator.set_player(manager.active_player);
             } catch (Error error) {
                 warning("Unable to monitor MPRIS players: %s", error.message);
             }
@@ -125,6 +127,13 @@ namespace MprisMiniPlayer {
         }
 
         private void on_player_priority_changed() {
+            if (main_window != null) {
+                main_window.refresh_players();
+            }
+        }
+
+        private void on_active_player_changed() {
+            status_indicator.set_player(manager != null ? manager.active_player : null);
             if (main_window != null) {
                 main_window.refresh_players();
             }
@@ -252,6 +261,44 @@ namespace MprisMiniPlayer {
                 case "hide":
                     hide_window();
                     break;
+                case "previous":
+                    if (manager != null && manager.active_player != null) {
+                        manager.active_player.previous();
+                    }
+                    break;
+                case "play-pause":
+                    if (manager != null && manager.active_player != null) {
+                        manager.active_player.play_pause();
+                    }
+                    break;
+                case "next":
+                    if (manager != null && manager.active_player != null) {
+                        manager.active_player.next();
+                    }
+                    break;
+                case "mute":
+                    if (manager != null && manager.active_player != null) {
+                        manager.active_player.toggle_mute();
+                    }
+                    break;
+                case "volume-25":
+                    set_active_player_volume(0.25);
+                    break;
+                case "volume-50":
+                    set_active_player_volume(0.50);
+                    break;
+                case "volume-75":
+                    set_active_player_volume(0.75);
+                    break;
+                case "volume-100":
+                    set_active_player_volume(1.0);
+                    break;
+                case "volume-up":
+                    adjust_active_player_volume(0.05);
+                    break;
+                case "volume-down":
+                    adjust_active_player_volume(-0.05);
+                    break;
                 case "preferences":
                     present_preferences();
                     break;
@@ -264,6 +311,18 @@ namespace MprisMiniPlayer {
                 case "quit":
                     quit_app();
                     break;
+            }
+        }
+
+        private void set_active_player_volume(double volume) {
+            if (manager != null && manager.active_player != null) {
+                manager.active_player.set_player_volume(volume);
+            }
+        }
+
+        private void adjust_active_player_volume(double delta) {
+            if (manager != null && manager.active_player != null) {
+                manager.active_player.adjust_volume(delta);
             }
         }
 

--- a/src/mpris-manager.vala
+++ b/src/mpris-manager.vala
@@ -11,9 +11,13 @@ namespace MprisMiniPlayer {
         private FreedesktopDBus dbus_proxy;
         private uint name_owner_subscription_id;
         private uint player_properties_subscription_id;
+        private bool manual_selection = false;
+
+        public MprisPlayer? active_player { get; private set; default = null; }
 
         public signal void players_changed();
         public signal void player_priority_changed();
+        public signal void active_player_changed();
 
         public MprisManager() throws Error {
             bus = Bus.get_sync(BusType.SESSION);
@@ -40,6 +44,7 @@ namespace MprisMiniPlayer {
                 DBusSignalFlags.NONE,
                 on_player_properties_changed
             );
+            refresh_active_player();
         }
 
         ~MprisManager() {
@@ -68,6 +73,36 @@ namespace MprisMiniPlayer {
             }
         }
 
+        public void select_player(string bus_name) {
+            string[] players = list_players();
+            if (!has_player(players, bus_name)) {
+                return;
+            }
+
+            manual_selection = true;
+            switch_active_player(bus_name);
+        }
+
+        public void refresh_active_player() {
+            string[] players = list_players();
+            if (players.length == 0) {
+                manual_selection = false;
+                clear_active_player();
+                return;
+            }
+
+            if (
+                manual_selection
+                && active_player != null
+                && has_player(players, active_player.bus_name)
+            ) {
+                return;
+            }
+
+            manual_selection = false;
+            switch_active_player(choose_best_player(players));
+        }
+
         private void on_name_owner_changed(
             DBusConnection connection,
             string? sender_name,
@@ -82,6 +117,7 @@ namespace MprisMiniPlayer {
             parameters.get("(sss)", out name, out old_owner, out new_owner);
 
             if (name.has_prefix(MPRIS_PREFIX)) {
+                refresh_active_player();
                 players_changed();
             }
         }
@@ -106,8 +142,65 @@ namespace MprisMiniPlayer {
                     || has_string(invalidated, "PlaybackStatus")
                 )
             ) {
+                if (!manual_selection) {
+                    refresh_active_player();
+                }
                 player_priority_changed();
             }
+        }
+
+        private void switch_active_player(string bus_name) {
+            if (active_player != null && active_player.bus_name == bus_name) {
+                return;
+            }
+
+            try {
+                active_player = new MprisPlayer(bus_name);
+                active_player_changed();
+            } catch (Error error) {
+                warning("Unable to select player %s: %s", bus_name, error.message);
+                clear_active_player();
+            }
+        }
+
+        private void clear_active_player() {
+            if (active_player == null) {
+                return;
+            }
+
+            active_player = null;
+            active_player_changed();
+        }
+
+        private string choose_best_player(string[] bus_names) {
+            string first_bus_name = bus_names[0];
+            string paused_bus_name = "";
+
+            foreach (var bus_name in bus_names) {
+                try {
+                    var candidate = new MprisPlayer(bus_name);
+                    if (candidate.playback_status == "Playing") {
+                        return bus_name;
+                    }
+                    if (paused_bus_name == "" && candidate.playback_status == "Paused") {
+                        paused_bus_name = bus_name;
+                    }
+                } catch (Error error) {
+                    warning("Unable to inspect player %s: %s", bus_name, error.message);
+                }
+            }
+
+            return paused_bus_name != "" ? paused_bus_name : first_bus_name;
+        }
+
+        private bool has_player(string[] bus_names, string bus_name) {
+            foreach (var candidate in bus_names) {
+                if (candidate == bus_name) {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private bool has_property(Variant dictionary, string key) {

--- a/src/mpris-player.vala
+++ b/src/mpris-player.vala
@@ -195,7 +195,7 @@ namespace MprisMiniPlayer {
                 return;
             }
 
-            set_player_volume(double.max(0.0, double.min(1.0, volume + delta)));
+            set_player_volume(double.max(0.0, volume + delta));
         }
 
         public string display_name() {

--- a/src/mpris-player.vala
+++ b/src/mpris-player.vala
@@ -7,6 +7,7 @@ namespace MprisMiniPlayer {
 
         private DBusConnection bus;
         private uint properties_subscription_id;
+        private double restore_volume = 1.0;
 
         public string bus_name { get; construct; }
         public string title { get; private set; default = "Unknown track"; }
@@ -166,11 +167,35 @@ namespace MprisMiniPlayer {
                     -1
                 );
                 this.volume = volume;
+                if (volume > 0.0) {
+                    restore_volume = volume;
+                }
                 changed();
             } catch (Error error) {
                 warning("Unable to set volume on %s: %s", bus_name, error.message);
                 refresh();
             }
+        }
+
+        public void toggle_mute() {
+            if (!has_volume || !can_control) {
+                return;
+            }
+
+            if (volume > 0.0) {
+                restore_volume = volume;
+                set_player_volume(0.0);
+            } else {
+                set_player_volume(restore_volume > 0.0 ? restore_volume : 1.0);
+            }
+        }
+
+        public void adjust_volume(double delta) {
+            if (!has_volume || !can_control) {
+                return;
+            }
+
+            set_player_volume(double.max(0.0, double.min(1.0, volume + delta)));
         }
 
         public string display_name() {
@@ -232,6 +257,9 @@ namespace MprisMiniPlayer {
             if (volume_value != null) {
                 has_volume = true;
                 volume = unwrap_variant(volume_value).get_double();
+                if (volume > 0.0) {
+                    restore_volume = volume;
+                }
             }
         }
 

--- a/src/status-indicator.vala
+++ b/src/status-indicator.vala
@@ -8,8 +8,10 @@ namespace MprisMiniPlayer {
     public class StatusNotifierItem : Object {
         private const string APP_ID = "io.github.ChrisLauinger.MprisMiniPlayer";
         private const string MENU_OBJECT_PATH = "/StatusNotifierMenu";
+        private string displayed_icon_name = APP_ID;
 
         public signal void activated();
+        public signal void scroll_requested(int delta, string orientation);
 
         [DBus (name = "NewIcon")]
         public signal void new_icon();
@@ -48,7 +50,7 @@ namespace MprisMiniPlayer {
         [DBus (name = "IconName")]
         public string icon_name {
             owned get {
-                return APP_ID;
+                return displayed_icon_name;
             }
         }
 
@@ -110,6 +112,31 @@ namespace MprisMiniPlayer {
 
         [DBus (name = "Scroll")]
         public void scroll(int delta, string orientation) throws DBusError, IOError {
+            scroll_requested(delta, orientation);
+        }
+
+        [DBus (visible = false)]
+        public void show_volume_icon(double volume) {
+            if (volume <= 0.0) {
+                displayed_icon_name = "audio-volume-muted-symbolic";
+            } else if (volume < 0.35) {
+                displayed_icon_name = "audio-volume-low-symbolic";
+            } else if (volume < 0.70) {
+                displayed_icon_name = "audio-volume-medium-symbolic";
+            } else {
+                displayed_icon_name = "audio-volume-high-symbolic";
+            }
+            new_icon();
+        }
+
+        [DBus (visible = false)]
+        public void restore_app_icon() {
+            if (displayed_icon_name == APP_ID) {
+                return;
+            }
+
+            displayed_icon_name = APP_ID;
+            new_icon();
         }
     }
 
@@ -122,9 +149,28 @@ namespace MprisMiniPlayer {
         private const int PREFERENCES_ID = 4;
         private const int ABOUT_ID = 5;
         private const int QUIT_ID = 6;
+        private const int MEDIA_SEPARATOR_ID = 7;
+        private const int SETTINGS_SEPARATOR_ID = 8;
+        private const int TITLE_ID = 10;
+        private const int ARTIST_ID = 11;
+        private const int ALBUM_ID = 12;
+        private const int NO_PLAYER_ID = 13;
+        private const int CONTROLS_SEPARATOR_ID = 14;
+        private const int PREVIOUS_ID = 20;
+        private const int PLAY_PAUSE_ID = 21;
+        private const int NEXT_ID = 22;
+        private const int VOLUME_ID = 30;
+        private const int MUTE_ID = 31;
+        private const int VOLUME_25_ID = 32;
+        private const int VOLUME_50_ID = 33;
+        private const int VOLUME_75_ID = 34;
+        private const int VOLUME_100_ID = 35;
 
         private uint revision = 1;
         private bool compact_mode = false;
+        private MprisPlayer? player;
+        private ulong player_changed_handler_id = 0;
+        private string player_state_signature = "none";
 
         public signal void action_requested(string action);
 
@@ -172,8 +218,26 @@ namespace MprisMiniPlayer {
             }
 
             compact_mode = enabled;
-            revision++;
-            layout_updated(revision, ROOT_ID);
+            notify_layout_changed();
+        }
+
+        [DBus (visible = false)]
+        public void set_player(MprisPlayer? selected_player) {
+            if (player == selected_player) {
+                return;
+            }
+
+            if (player != null && player_changed_handler_id != 0) {
+                SignalHandler.disconnect(player, player_changed_handler_id);
+                player_changed_handler_id = 0;
+            }
+
+            player = selected_player;
+            if (player != null) {
+                player_changed_handler_id = player.changed.connect(on_player_changed);
+            }
+            player_state_signature = build_player_state_signature();
+            notify_layout_changed();
         }
 
         [DBus (name = "GetLayout")]
@@ -186,18 +250,22 @@ namespace MprisMiniPlayer {
             out Variant layout
         ) throws DBusError, IOError {
             revision = this.revision;
-            layout = build_layout();
+            if (parent_id == VOLUME_ID) {
+                layout = build_volume_item(recursion_depth);
+            } else if (parent_id == ROOT_ID) {
+                layout = build_layout(recursion_depth);
+            } else {
+                layout = build_item(parent_id);
+            }
         }
 
         [DBus (name = "GetGroupProperties", signature = "a(ia{sv})")]
         public Variant get_group_properties(int[] ids, string[] property_names) throws DBusError, IOError {
             var items = new VariantBuilder(new VariantType("a(ia{sv})"));
-            int[] requested_ids = ids.length == 0
-                ? new int[] { SHOW_ID, HIDE_ID, COMPACT_MODE_ID, PREFERENCES_ID, ABOUT_ID, QUIT_ID }
-                : ids;
+            int[] requested_ids = ids.length == 0 ? all_ids() : ids;
 
             foreach (int id in requested_ids) {
-                if (id == ROOT_ID || id == SHOW_ID || id == HIDE_ID || id == COMPACT_MODE_ID || id == PREFERENCES_ID || id == ABOUT_ID || id == QUIT_ID) {
+                if (is_known_id(id)) {
                     items.add_value(new Variant.tuple({
                         new Variant.int32(id),
                         build_properties(id)
@@ -220,7 +288,7 @@ namespace MprisMiniPlayer {
 
         [DBus (name = "Event")]
         public void event(int id, string event_id, Variant data, uint timestamp) throws DBusError, IOError {
-            if (event_id == "clicked") {
+            if (event_id == "clicked" && is_enabled(id)) {
                 activate_item(id);
             }
         }
@@ -240,14 +308,36 @@ namespace MprisMiniPlayer {
             id_errors = {};
         }
 
-        private Variant build_layout() {
+        private Variant build_layout(int recursion_depth = -1) {
             var children = new VariantBuilder(new VariantType("av"));
-            children.add_value(new Variant.variant(build_item(SHOW_ID)));
-            children.add_value(new Variant.variant(build_item(HIDE_ID)));
-            children.add_value(new Variant.variant(build_item(COMPACT_MODE_ID)));
-            children.add_value(new Variant.variant(build_item(PREFERENCES_ID)));
-            children.add_value(new Variant.variant(build_item(ABOUT_ID)));
-            children.add_value(new Variant.variant(build_item(QUIT_ID)));
+            if (recursion_depth != 0) {
+                children.add_value(new Variant.variant(build_item(SHOW_ID)));
+                children.add_value(new Variant.variant(build_item(HIDE_ID)));
+                children.add_value(new Variant.variant(build_item(MEDIA_SEPARATOR_ID)));
+
+                if (player == null) {
+                    children.add_value(new Variant.variant(build_item(NO_PLAYER_ID)));
+                } else {
+                    children.add_value(new Variant.variant(build_item(TITLE_ID)));
+                    children.add_value(new Variant.variant(build_item(ARTIST_ID)));
+                    if (player.album != "") {
+                        children.add_value(new Variant.variant(build_item(ALBUM_ID)));
+                    }
+                    children.add_value(new Variant.variant(build_item(CONTROLS_SEPARATOR_ID)));
+                    children.add_value(new Variant.variant(build_item(PREVIOUS_ID)));
+                    children.add_value(new Variant.variant(build_item(PLAY_PAUSE_ID)));
+                    children.add_value(new Variant.variant(build_item(NEXT_ID)));
+                    if (player.has_volume) {
+                        children.add_value(new Variant.variant(build_volume_item(recursion_depth - 1)));
+                    }
+                }
+
+                children.add_value(new Variant.variant(build_item(SETTINGS_SEPARATOR_ID)));
+                children.add_value(new Variant.variant(build_item(COMPACT_MODE_ID)));
+                children.add_value(new Variant.variant(build_item(PREFERENCES_ID)));
+                children.add_value(new Variant.variant(build_item(ABOUT_ID)));
+                children.add_value(new Variant.variant(build_item(QUIT_ID)));
+            }
 
             var root_properties = new VariantBuilder(new VariantType("a{sv}"));
             root_properties.add("{sv}", "children-display", new Variant.string("submenu"));
@@ -268,15 +358,53 @@ namespace MprisMiniPlayer {
             });
         }
 
+        private Variant build_volume_item(int recursion_depth = -1) {
+            var children = new VariantBuilder(new VariantType("av"));
+            if (recursion_depth != 0) {
+                children.add_value(new Variant.variant(build_item(MUTE_ID)));
+                children.add_value(new Variant.variant(build_item(VOLUME_25_ID)));
+                children.add_value(new Variant.variant(build_item(VOLUME_50_ID)));
+                children.add_value(new Variant.variant(build_item(VOLUME_75_ID)));
+                children.add_value(new Variant.variant(build_item(VOLUME_100_ID)));
+            }
+
+            return new Variant.tuple({
+                new Variant.int32(VOLUME_ID),
+                build_properties(VOLUME_ID),
+                children.end()
+            });
+        }
+
         private Variant build_properties(int id) {
             var properties = new VariantBuilder(new VariantType("a{sv}"));
-            properties.add("{sv}", "enabled", new Variant.boolean(true));
+            if (is_separator(id)) {
+                properties.add("{sv}", "type", new Variant.string("separator"));
+                properties.add("{sv}", "visible", new Variant.boolean(true));
+                return properties.end();
+            }
+
+            properties.add("{sv}", "enabled", new Variant.boolean(is_enabled(id)));
             properties.add("{sv}", "visible", new Variant.boolean(true));
             properties.add("{sv}", "type", new Variant.string("standard"));
             properties.add("{sv}", "label", new Variant.string(get_label(id)));
+            string icon_name = get_icon_name(id);
+            if (icon_name != "") {
+                properties.add("{sv}", "icon-name", new Variant.string(icon_name));
+            }
             if (id == COMPACT_MODE_ID) {
                 properties.add("{sv}", "toggle-type", new Variant.string("checkmark"));
                 properties.add("{sv}", "toggle-state", new Variant.int32(compact_mode ? 1 : 0));
+            }
+            if (is_volume_preset(id)) {
+                properties.add("{sv}", "toggle-type", new Variant.string("radio"));
+                properties.add(
+                    "{sv}",
+                    "toggle-state",
+                    new Variant.int32(volume_matches_preset(id) ? 1 : 0)
+                );
+            }
+            if (id == VOLUME_ID) {
+                properties.add("{sv}", "children-display", new Variant.string("submenu"));
             }
             return properties.end();
         }
@@ -287,6 +415,36 @@ namespace MprisMiniPlayer {
                     return _("Show");
                 case HIDE_ID:
                     return _("Hide");
+                case TITLE_ID:
+                    return truncate_label(player != null ? player.title : "", 30);
+                case ARTIST_ID:
+                    return truncate_label(player != null ? player.artist : "", 30);
+                case ALBUM_ID:
+                    return escape_label(player != null ? player.album : "");
+                case NO_PLAYER_ID:
+                    return _("No player detected");
+                case PREVIOUS_ID:
+                    return _("Previous");
+                case PLAY_PAUSE_ID:
+                    return player != null && player.playback_status == "Playing"
+                        ? _("Pause")
+                        : _("Play");
+                case NEXT_ID:
+                    return _("Next");
+                case VOLUME_ID:
+                    return _("Volume: %d%%").printf(current_volume_percent());
+                case MUTE_ID:
+                    return player != null && player.volume > 0.0
+                        ? _("Mute")
+                        : _("Restore volume");
+                case VOLUME_25_ID:
+                    return "25%";
+                case VOLUME_50_ID:
+                    return "50%";
+                case VOLUME_75_ID:
+                    return "75%";
+                case VOLUME_100_ID:
+                    return "100%";
                 case COMPACT_MODE_ID:
                     return _("Compact Mode");
                 case PREFERENCES_ID:
@@ -308,6 +466,30 @@ namespace MprisMiniPlayer {
                 case HIDE_ID:
                     action_requested("hide");
                     break;
+                case PREVIOUS_ID:
+                    action_requested("previous");
+                    break;
+                case PLAY_PAUSE_ID:
+                    action_requested("play-pause");
+                    break;
+                case NEXT_ID:
+                    action_requested("next");
+                    break;
+                case MUTE_ID:
+                    action_requested("mute");
+                    break;
+                case VOLUME_25_ID:
+                    action_requested("volume-25");
+                    break;
+                case VOLUME_50_ID:
+                    action_requested("volume-50");
+                    break;
+                case VOLUME_75_ID:
+                    action_requested("volume-75");
+                    break;
+                case VOLUME_100_ID:
+                    action_requested("volume-100");
+                    break;
                 case COMPACT_MODE_ID:
                     action_requested("compact-mode");
                     break;
@@ -323,6 +505,164 @@ namespace MprisMiniPlayer {
                 default:
                     return;
             }
+        }
+
+        private void notify_layout_changed() {
+            revision++;
+            layout_updated(revision, ROOT_ID);
+        }
+
+        private void on_player_changed() {
+            string new_signature = build_player_state_signature();
+            if (new_signature == player_state_signature) {
+                return;
+            }
+
+            player_state_signature = new_signature;
+            notify_layout_changed();
+        }
+
+        private string build_player_state_signature() {
+            if (player == null) {
+                return "none";
+            }
+
+            return "%s\x1f%s\x1f%s\x1f%s\x1f%d\x1f%d\x1f%d\x1f%d\x1f%d\x1f%d\x1f%d".printf(
+                player.title,
+                player.artist,
+                player.album,
+                player.playback_status,
+                player.can_go_previous ? 1 : 0,
+                player.can_go_next ? 1 : 0,
+                player.can_play ? 1 : 0,
+                player.can_pause ? 1 : 0,
+                player.can_control ? 1 : 0,
+                player.has_volume ? 1 : 0,
+                current_volume_percent()
+            );
+        }
+
+        private int[] all_ids() {
+            return {
+                ROOT_ID,
+                SHOW_ID,
+                HIDE_ID,
+                COMPACT_MODE_ID,
+                PREFERENCES_ID,
+                ABOUT_ID,
+                QUIT_ID,
+                MEDIA_SEPARATOR_ID,
+                SETTINGS_SEPARATOR_ID,
+                TITLE_ID,
+                ARTIST_ID,
+                ALBUM_ID,
+                NO_PLAYER_ID,
+                CONTROLS_SEPARATOR_ID,
+                PREVIOUS_ID,
+                PLAY_PAUSE_ID,
+                NEXT_ID,
+                VOLUME_ID,
+                MUTE_ID,
+                VOLUME_25_ID,
+                VOLUME_50_ID,
+                VOLUME_75_ID,
+                VOLUME_100_ID
+            };
+        }
+
+        private bool is_known_id(int id) {
+            foreach (int known_id in all_ids()) {
+                if (id == known_id) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private bool is_separator(int id) {
+            return id == MEDIA_SEPARATOR_ID
+                || id == SETTINGS_SEPARATOR_ID
+                || id == CONTROLS_SEPARATOR_ID;
+        }
+
+        private bool is_enabled(int id) {
+            if (
+                id == TITLE_ID
+                || id == ARTIST_ID
+                || id == ALBUM_ID
+                || id == NO_PLAYER_ID
+            ) {
+                return false;
+            }
+            if (id == PREVIOUS_ID) {
+                return player != null && player.can_go_previous;
+            }
+            if (id == PLAY_PAUSE_ID) {
+                return player != null
+                    && (
+                        player.playback_status == "Playing"
+                            ? player.can_pause
+                            : player.can_play
+                    );
+            }
+            if (id == NEXT_ID) {
+                return player != null && player.can_go_next;
+            }
+            if (id == VOLUME_ID || id == MUTE_ID || is_volume_preset(id)) {
+                return player != null && player.has_volume && player.can_control;
+            }
+            return true;
+        }
+
+        private string get_icon_name(int id) {
+            switch (id) {
+                case PREVIOUS_ID:
+                    return "media-skip-backward-symbolic";
+                case PLAY_PAUSE_ID:
+                    return player != null && player.playback_status == "Playing"
+                        ? "media-playback-pause-symbolic"
+                        : "media-playback-start-symbolic";
+                case NEXT_ID:
+                    return "media-skip-forward-symbolic";
+                case VOLUME_ID:
+                    return current_volume_percent() == 0
+                        ? "audio-volume-muted-symbolic"
+                        : "audio-volume-high-symbolic";
+                case MUTE_ID:
+                    return "audio-volume-muted-symbolic";
+                default:
+                    return "";
+            }
+        }
+
+        private bool is_volume_preset(int id) {
+            return id >= VOLUME_25_ID && id <= VOLUME_100_ID;
+        }
+
+        private bool volume_matches_preset(int id) {
+            if (player == null) {
+                return false;
+            }
+
+            int preset = (id - VOLUME_25_ID + 1) * 25;
+            return current_volume_percent() == preset;
+        }
+
+        private int current_volume_percent() {
+            return player == null ? 0 : (int) (player.volume * 100.0 + 0.5);
+        }
+
+        private string escape_label(string label) {
+            return label.replace("_", "__");
+        }
+
+        private string truncate_label(string label, int max_chars) {
+            if (label.char_count() <= max_chars) {
+                return escape_label(label);
+            }
+
+            int end = label.index_of_nth_char(max_chars - 1);
+            return escape_label(label.substring(0, end)) + "…";
         }
     }
 
@@ -342,8 +682,10 @@ namespace MprisMiniPlayer {
         private uint item_registration_id = 0;
         private uint menu_registration_id = 0;
         private uint name_owner_subscription_id = 0;
+        private uint volume_icon_timeout_id = 0;
         private bool enabled = false;
         private bool compact_mode = false;
+        private MprisPlayer? player;
 
         public bool supported { get; private set; default = false; }
 
@@ -380,7 +722,16 @@ namespace MprisMiniPlayer {
             }
         }
 
+        public void set_player(MprisPlayer? selected_player) {
+            player = selected_player;
+
+            if (menu != null) {
+                menu.set_player(selected_player);
+            }
+        }
+
         public void shutdown() {
+            clear_volume_icon_timeout();
             if (bus != null && name_owner_subscription_id != 0) {
                 bus.signal_unsubscribe(name_owner_subscription_id);
                 name_owner_subscription_id = 0;
@@ -463,8 +814,23 @@ namespace MprisMiniPlayer {
 
             item = new StatusNotifierItem();
             item.activated.connect(() => activated());
+            item.scroll_requested.connect((delta, orientation) => {
+                if (
+                    orientation != "vertical"
+                    || delta == 0
+                    || player == null
+                    || !player.has_volume
+                    || !player.can_control
+                ) {
+                    return;
+                }
+
+                action_requested(delta > 0 ? "volume-up" : "volume-down");
+                show_volume_icon_feedback();
+            });
             menu = new StatusNotifierMenu();
             menu.set_compact_mode(compact_mode);
+            menu.set_player(player);
             menu.action_requested.connect((action) => action_requested(action));
 
             try {
@@ -497,6 +863,7 @@ namespace MprisMiniPlayer {
         }
 
         private void unregister_item() {
+            clear_volume_icon_timeout();
             if (bus != null && item_registration_id != 0) {
                 bus.unregister_object(item_registration_id);
                 item_registration_id = 0;
@@ -508,6 +875,31 @@ namespace MprisMiniPlayer {
 
             item = null;
             menu = null;
+        }
+
+        private void show_volume_icon_feedback() {
+            if (item == null || player == null) {
+                return;
+            }
+
+            item.show_volume_icon(player.volume);
+            clear_volume_icon_timeout();
+            volume_icon_timeout_id = Timeout.add(1500, () => {
+                volume_icon_timeout_id = 0;
+                if (item != null) {
+                    item.restore_app_icon();
+                }
+                return Source.REMOVE;
+            });
+        }
+
+        private void clear_volume_icon_timeout() {
+            if (volume_icon_timeout_id == 0) {
+                return;
+            }
+
+            Source.remove(volume_icon_timeout_id);
+            volume_icon_timeout_id = 0;
         }
 
         private static bool is_flatpak() {

--- a/src/window.vala
+++ b/src/window.vala
@@ -2,7 +2,7 @@ namespace MprisMiniPlayer {
     public class Window : Adw.ApplicationWindow {
         private MprisManager? manager;
         private MprisPlayer? player;
-        private bool manual_selection = false;
+        private ulong player_changed_handler_id = 0;
         private bool compact_mode = false;
         private bool album_tint_enabled = false;
         private string current_art_url = "";
@@ -34,7 +34,6 @@ namespace MprisMiniPlayer {
         private uint position_timeout_id = 0;
         private bool updating_progress = false;
         private bool updating_volume = false;
-        private double restore_volume = 1.0;
 
         public Window(
             Gtk.Application app,
@@ -61,6 +60,9 @@ namespace MprisMiniPlayer {
             );
 
             build_ui();
+            if (manager != null) {
+                manager.active_player_changed.connect(sync_active_player);
+            }
             set_compact_mode(compact_mode);
             start_position_timer();
             refresh_players();
@@ -76,7 +78,10 @@ namespace MprisMiniPlayer {
         }
 
         public void refresh_players() {
-            select_player_for_current_state();
+            if (manager != null) {
+                manager.refresh_active_player();
+            }
+            sync_active_player();
         }
 
         public void set_compact_mode(bool compact_mode) {
@@ -268,10 +273,9 @@ namespace MprisMiniPlayer {
             update_controls(false);
         }
 
-        private void select_player_for_current_state() {
+        private void sync_active_player() {
             if (manager == null) {
-                player = null;
-                manual_selection = false;
+                set_player(null);
                 show_empty_state(_("Session D-Bus unavailable"), _("Unable to monitor MPRIS players"));
                 return;
             }
@@ -280,39 +284,37 @@ namespace MprisMiniPlayer {
             rebuild_player_list(players);
 
             if (players.length == 0) {
-                player = null;
-                manual_selection = false;
+                set_player(null);
                 show_empty_state(_("No player detected"), _("Start any MPRIS-compatible player"));
                 return;
             }
 
-            string selected_bus_name;
-            if (manual_selection && player != null && has_player(players, player.bus_name)) {
-                selected_bus_name = player.bus_name;
-            } else {
-                manual_selection = false;
-                selected_bus_name = choose_best_player(players);
-            }
-
-            if (player != null && player.bus_name == selected_bus_name) {
-                player.refresh();
+            if (manager.active_player == null) {
+                set_player(null);
+                show_empty_state(_("Player unavailable"), _("Unable to monitor MPRIS players"));
                 return;
             }
 
-            select_player(selected_bus_name);
+            set_player(manager.active_player);
         }
 
-        private void select_player(string bus_name) {
-            try {
-                player = new MprisPlayer(bus_name);
-                player.changed.connect(update_player_state);
-                update_player_state();
-                if (manager != null) {
-                    rebuild_player_list(manager.list_players());
+        private void set_player(MprisPlayer? selected_player) {
+            if (player == selected_player) {
+                if (player != null) {
+                    update_player_state();
                 }
-            } catch (Error error) {
-                warning("Unable to select player %s: %s", bus_name, error.message);
-                show_empty_state(_("Player unavailable"), error.message);
+                return;
+            }
+
+            if (player != null && player_changed_handler_id != 0) {
+                SignalHandler.disconnect(player, player_changed_handler_id);
+                player_changed_handler_id = 0;
+            }
+
+            player = selected_player;
+            if (player != null) {
+                player_changed_handler_id = player.changed.connect(update_player_state);
+                update_player_state();
             }
         }
 
@@ -496,9 +498,11 @@ namespace MprisMiniPlayer {
             button.hexpand = true;
             button.clicked.connect(() => {
                 player_popover.popdown();
-                if (player == null || player.bus_name != listed_player.bus_name) {
-                    manual_selection = true;
-                    select_player(listed_player.bus_name);
+                if (
+                    manager != null
+                    && (player == null || player.bus_name != listed_player.bus_name)
+                ) {
+                    manager.select_player(listed_player.bus_name);
                 }
             });
 
@@ -526,41 +530,6 @@ namespace MprisMiniPlayer {
             }
 
             return button;
-        }
-
-        private bool has_player(string[] bus_names, string bus_name) {
-            foreach (var candidate in bus_names) {
-                if (candidate == bus_name) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private string choose_best_player(string[] bus_names) {
-            string first_bus_name = bus_names[0];
-            string paused_bus_name = "";
-
-            foreach (var bus_name in bus_names) {
-                try {
-                    var candidate = new MprisPlayer(bus_name);
-                    if (candidate.playback_status == "Playing") {
-                        return bus_name;
-                    }
-                    if (paused_bus_name == "" && candidate.playback_status == "Paused") {
-                        paused_bus_name = bus_name;
-                    }
-                } catch (Error error) {
-                    warning("Unable to inspect player %s: %s", bus_name, error.message);
-                }
-            }
-
-            if (paused_bus_name != "") {
-                return paused_bus_name;
-            }
-
-            return first_bus_name;
         }
 
         private void start_position_timer() {
@@ -626,9 +595,6 @@ namespace MprisMiniPlayer {
             volume_scale.set_value(has_volume ? slider_volume(player.volume) : 0);
             updating_volume = false;
 
-            if (has_volume && player.volume > 0.0) {
-                restore_volume = player.volume;
-            }
             update_volume_button();
         }
 
@@ -638,9 +604,6 @@ namespace MprisMiniPlayer {
             }
 
             double volume = volume_scale.get_value();
-            if (volume > 0.0) {
-                restore_volume = volume;
-            }
             player.set_player_volume(volume);
         }
 
@@ -649,13 +612,7 @@ namespace MprisMiniPlayer {
                 return;
             }
 
-            if (player.volume > 0.0) {
-                restore_volume = player.volume;
-                player.set_player_volume(0.0);
-                return;
-            }
-
-            player.set_player_volume(restore_volume > 0.0 ? restore_volume : 1.0);
+            player.toggle_mute();
         }
 
         private double slider_volume(double volume) {


### PR DESCRIPTION
## Summary

- show the active track title, artist, and album in the status notifier menu
- add capability-aware previous, play/pause, next, mute, and preset volume controls
- share active-player selection between the main window and status notifier
- adjust player volume in 5% steps by scrolling over the notifier
- briefly show a volume-level icon after scrolling, then restore the app icon
- truncate long title and artist labels to 30 Unicode characters
- update German, Spanish, and French translations

## Why

The status notifier previously exposed only application actions, so controlling current playback required opening the main window. This makes the notifier useful as a compact media controller while keeping it synchronized with the window's selected player.

The volume submenu initially closed during playback because every MPRIS change, including periodic position updates, triggered a complete menu layout refresh. The menu now compares only visible state and refreshes when metadata, playback status, capabilities, or volume actually changes.

## Validation

- `meson compile -C build`
- `desktop-file-validate build/data/io.github.ChrisLauinger.MprisMiniPlayer.desktop`
- `appstreamcli validate --no-net build/data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml`
- `msgfmt --check` for all translation catalogs, with no fuzzy or untranslated entries
- live D-Bus testing with mpv for menu layout, nested volume submenu loading, presets, mute/restore, and 5% wheel adjustments
- verified ordinary playback-position updates no longer emit `LayoutUpdated`
- verified temporary volume icons reset to the application icon after 1.5 seconds