### PR TITLE
Add notifier update checks and fix volume scrolling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
             gettext \
             libadwaita-1-dev \
             libgtk-4-dev \
+            libsoup-3.0-dev \
             meson \
             ninja-build \
             valac
@@ -91,6 +92,7 @@ jobs:
             git \
             gtk4-devel \
             libadwaita-devel \
+            libsoup3-devel \
             meson \
             rpm-build \
             vala

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ Typical Debian dependencies:
 sudo apt install \
   meson ninja-build valac \
   libgtk-4-dev libadwaita-1-dev \
+  libsoup-3.0-dev \
   gettext desktop-file-utils appstream-util
 ```
 
@@ -113,6 +114,7 @@ Typical Fedora dependencies for building the application and RPM package:
 sudo dnf install \
   desktop-file-utils gcc gettext git \
   gtk4-devel libadwaita-devel meson \
+  libsoup3-devel \
   rpm-build vala
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ When it starts without a player, it can stay hidden in the background and show t
 - Can show and hide the window automatically as players appear or disappear
 - Can show a status indicator with show, hide, compact mode, settings, about, and quit actions when the desktop supports it
 - Provides preferences for compact mode, background notifications, automatic visibility, status indicators, and start on login
+- Shows a status indicator link when a newer stable release is available
 - Hides the window on close; use Quit to stop the app
 
 ## Build from Source
@@ -75,7 +76,7 @@ When it starts without a player, it can stay hidden in the background and show t
 Install the typical development dependencies on Debian or Ubuntu:
 
 ```bash
-sudo apt install meson ninja-build valac libgtk-4-dev libadwaita-1-dev gettext desktop-file-utils appstream
+sudo apt install meson ninja-build valac libgtk-4-dev libadwaita-1-dev libsoup-3.0-dev gettext desktop-file-utils appstream
 ```
 
 Build and run:

--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Build-Depends:
  gettext,
  libadwaita-1-dev,
  libgtk-4-dev,
+ libsoup-3.0-dev,
  meson,
  ninja-build,
  valac

--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,19 @@ subdir('src')
 subdir('data')
 subdir('po')
 
+update_checker_test = executable(
+  'update-checker-test',
+  [
+    config_vala,
+    'src/update-checker.vala',
+    'tests/update-checker-test.vala',
+  ],
+  dependencies: dependency('libsoup-3.0'),
+  vala_args: ['--target-glib=2.66'],
+)
+
+test('update checker version comparison', update_checker_test)
+
 gnome.post_install(
   glib_compile_schemas: true,
   gtk_update_icon_cache: true,

--- a/po/de.po
+++ b/po/de.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mpris-miniplayer 0.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-15 10:41+0200\n"
+"POT-Creation-Date: 2026-08-15 11:37+0200\n"
 "PO-Revision-Date: 2026-06-21 09:39+0200\n"
 "Last-Translator: Christian Lauinger\n"
 "Language-Team: German\n"
@@ -14,7 +14,7 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in:2
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:6
-#: src/status-indicator.vala:38 src/application.vala:208 src/window.vala:46
+#: src/status-indicator.vala:39 src/application.vala:213 src/window.vala:46
 msgid "MPRIS MiniPlayer"
 msgstr "MPRIS MiniPlayer"
 
@@ -43,69 +43,74 @@ msgstr "Medienspieler überwachen"
 msgid "Keep watching for MPRIS-compatible media players"
 msgstr "Weiter nach MPRIS-kompatiblen Medienspielern suchen"
 
-#: src/status-indicator.vala:390
+#: src/status-indicator.vala:434
 msgid "Show"
 msgstr "Anzeigen"
 
-#: src/status-indicator.vala:392
+#: src/status-indicator.vala:436
 msgid "Hide"
 msgstr "Ausblenden"
 
-#: src/status-indicator.vala:400 src/window.vala:288
+#: src/status-indicator.vala:438
+#, c-format
+msgid "Update available: %s"
+msgstr "Aktualisierung verfügbar: %s"
+
+#: src/status-indicator.vala:446 src/window.vala:288
 msgid "No player detected"
 msgstr "Kein Medienspieler erkannt"
 
-#: src/status-indicator.vala:402 src/window.vala:240
+#: src/status-indicator.vala:448 src/window.vala:240
 msgid "Previous"
 msgstr "Zurück"
 
-#: src/status-indicator.vala:405
+#: src/status-indicator.vala:451
 msgid "Pause"
 msgstr "Pause"
 
-#: src/status-indicator.vala:406
+#: src/status-indicator.vala:452
 msgid "Play"
 msgstr "Wiedergabe"
 
-#: src/status-indicator.vala:408 src/window.vala:259
+#: src/status-indicator.vala:454 src/window.vala:259
 msgid "Next"
 msgstr "Weiter"
 
-#: src/status-indicator.vala:410
+#: src/status-indicator.vala:456
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Lautstärke: %d%%"
 
-#: src/status-indicator.vala:413 src/window.vala:636
+#: src/status-indicator.vala:459 src/window.vala:636
 msgid "Mute"
 msgstr "Stummschalten"
 
-#: src/status-indicator.vala:414 src/window.vala:632
+#: src/status-indicator.vala:460 src/window.vala:632
 msgid "Restore volume"
 msgstr "Lautstärke wiederherstellen"
 
-#: src/status-indicator.vala:424 src/window.vala:136
+#: src/status-indicator.vala:470 src/window.vala:136
 msgid "Compact Mode"
 msgstr "Kompakter Modus"
 
-#: src/status-indicator.vala:426 src/preferences-window.vala:15
+#: src/status-indicator.vala:472 src/preferences-window.vala:15
 #: src/preferences-window.vala:32 src/window.vala:137
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: src/status-indicator.vala:428
+#: src/status-indicator.vala:474
 msgid "About"
 msgstr "Info"
 
-#: src/status-indicator.vala:430 src/window.vala:138
+#: src/status-indicator.vala:476 src/window.vala:138
 msgid "Quit"
 msgstr "Beenden"
 
-#: src/application.vala:334
+#: src/application.vala:373
 msgid "MPRIS MiniPlayer is running in the background"
 msgstr "MPRIS MiniPlayer läuft im Hintergrund"
 
-#: src/application.vala:336
+#: src/application.vala:375
 msgid ""
 "The window will appear automatically when a compatible media player becomes "
 "available."
@@ -113,12 +118,12 @@ msgstr ""
 "Das Fenster erscheint automatisch, sobald ein kompatibler Medienspieler "
 "verfügbar ist."
 
-#: src/application.vala:338
+#: src/application.vala:377
 msgid "Open the window when you want to control a compatible media player."
 msgstr ""
 "Öffne das Fenster, wenn du einen kompatiblen Medienspieler steuern möchtest."
 
-#: src/application.vala:340
+#: src/application.vala:379
 msgid "Open"
 msgstr "Öffnen"
 
@@ -224,11 +229,11 @@ msgstr "Starte einen MPRIS-kompatiblen Medienspieler"
 msgid "Player unavailable"
 msgstr "Medienspieler nicht verfügbar"
 
-#: src/mpris-player.vala:268
+#: src/mpris-player.vala:276
 msgid "Unknown track"
 msgstr "Unbekannter Titel"
 
-#: src/mpris-player.vala:275
+#: src/mpris-player.vala:283
 msgid "Unknown artist"
 msgstr "Unbekannter Künstler"
 

--- a/po/es.po
+++ b/po/es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mpris-miniplayer 0.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-15 10:41+0200\n"
+"POT-Creation-Date: 2026-08-15 11:37+0200\n"
 "PO-Revision-Date: 2026-06-21 09:39+0200\n"
 "Last-Translator: Christian Lauinger\n"
 "Language-Team: Spanish\n"
@@ -14,7 +14,7 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in:2
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:6
-#: src/status-indicator.vala:38 src/application.vala:208 src/window.vala:46
+#: src/status-indicator.vala:39 src/application.vala:213 src/window.vala:46
 msgid "MPRIS MiniPlayer"
 msgstr "MPRIS MiniPlayer"
 
@@ -43,69 +43,74 @@ msgstr "Supervisando reproductores multimedia"
 msgid "Keep watching for MPRIS-compatible media players"
 msgstr "Seguir buscando reproductores multimedia compatibles con MPRIS"
 
-#: src/status-indicator.vala:390
+#: src/status-indicator.vala:434
 msgid "Show"
 msgstr "Mostrar"
 
-#: src/status-indicator.vala:392
+#: src/status-indicator.vala:436
 msgid "Hide"
 msgstr "Ocultar"
 
-#: src/status-indicator.vala:400 src/window.vala:288
+#: src/status-indicator.vala:438
+#, c-format
+msgid "Update available: %s"
+msgstr "Actualización disponible: %s"
+
+#: src/status-indicator.vala:446 src/window.vala:288
 msgid "No player detected"
 msgstr "No se detectó ningún reproductor"
 
-#: src/status-indicator.vala:402 src/window.vala:240
+#: src/status-indicator.vala:448 src/window.vala:240
 msgid "Previous"
 msgstr "Anterior"
 
-#: src/status-indicator.vala:405
+#: src/status-indicator.vala:451
 msgid "Pause"
 msgstr "Pausa"
 
-#: src/status-indicator.vala:406
+#: src/status-indicator.vala:452
 msgid "Play"
 msgstr "Reproducir"
 
-#: src/status-indicator.vala:408 src/window.vala:259
+#: src/status-indicator.vala:454 src/window.vala:259
 msgid "Next"
 msgstr "Siguiente"
 
-#: src/status-indicator.vala:410
+#: src/status-indicator.vala:456
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Volumen: %d%%"
 
-#: src/status-indicator.vala:413 src/window.vala:636
+#: src/status-indicator.vala:459 src/window.vala:636
 msgid "Mute"
 msgstr "Silenciar"
 
-#: src/status-indicator.vala:414 src/window.vala:632
+#: src/status-indicator.vala:460 src/window.vala:632
 msgid "Restore volume"
 msgstr "Restaurar volumen"
 
-#: src/status-indicator.vala:424 src/window.vala:136
+#: src/status-indicator.vala:470 src/window.vala:136
 msgid "Compact Mode"
 msgstr "Modo compacto"
 
-#: src/status-indicator.vala:426 src/preferences-window.vala:15
+#: src/status-indicator.vala:472 src/preferences-window.vala:15
 #: src/preferences-window.vala:32 src/window.vala:137
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: src/status-indicator.vala:428
+#: src/status-indicator.vala:474
 msgid "About"
 msgstr "Acerca de"
 
-#: src/status-indicator.vala:430 src/window.vala:138
+#: src/status-indicator.vala:476 src/window.vala:138
 msgid "Quit"
 msgstr "Salir"
 
-#: src/application.vala:334
+#: src/application.vala:373
 msgid "MPRIS MiniPlayer is running in the background"
 msgstr "MPRIS MiniPlayer se está ejecutando en segundo plano"
 
-#: src/application.vala:336
+#: src/application.vala:375
 msgid ""
 "The window will appear automatically when a compatible media player becomes "
 "available."
@@ -113,13 +118,13 @@ msgstr ""
 "La ventana aparecerá automáticamente cuando haya disponible un reproductor "
 "multimedia compatible."
 
-#: src/application.vala:338
+#: src/application.vala:377
 msgid "Open the window when you want to control a compatible media player."
 msgstr ""
 "Abre la ventana cuando quieras controlar un reproductor multimedia "
 "compatible."
 
-#: src/application.vala:340
+#: src/application.vala:379
 msgid "Open"
 msgstr "Abrir"
 
@@ -225,11 +230,11 @@ msgstr "Inicia cualquier reproductor compatible con MPRIS"
 msgid "Player unavailable"
 msgstr "Reproductor no disponible"
 
-#: src/mpris-player.vala:268
+#: src/mpris-player.vala:276
 msgid "Unknown track"
 msgstr "Pista desconocida"
 
-#: src/mpris-player.vala:275
+#: src/mpris-player.vala:283
 msgid "Unknown artist"
 msgstr "Artista desconocido"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mpris-miniplayer 0.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-15 10:41+0200\n"
+"POT-Creation-Date: 2026-08-15 11:37+0200\n"
 "PO-Revision-Date: 2026-06-21 09:39+0200\n"
 "Last-Translator: Christian Lauinger\n"
 "Language-Team: French\n"
@@ -14,7 +14,7 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in:2
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:6
-#: src/status-indicator.vala:38 src/application.vala:208 src/window.vala:46
+#: src/status-indicator.vala:39 src/application.vala:213 src/window.vala:46
 msgid "MPRIS MiniPlayer"
 msgstr "MPRIS MiniPlayer"
 
@@ -43,69 +43,74 @@ msgstr "Surveillance des lecteurs multimédias"
 msgid "Keep watching for MPRIS-compatible media players"
 msgstr "Continuer à surveiller les lecteurs multimédias compatibles MPRIS"
 
-#: src/status-indicator.vala:390
+#: src/status-indicator.vala:434
 msgid "Show"
 msgstr "Afficher"
 
-#: src/status-indicator.vala:392
+#: src/status-indicator.vala:436
 msgid "Hide"
 msgstr "Masquer"
 
-#: src/status-indicator.vala:400 src/window.vala:288
+#: src/status-indicator.vala:438
+#, c-format
+msgid "Update available: %s"
+msgstr "Mise à jour disponible : %s"
+
+#: src/status-indicator.vala:446 src/window.vala:288
 msgid "No player detected"
 msgstr "Aucun lecteur détecté"
 
-#: src/status-indicator.vala:402 src/window.vala:240
+#: src/status-indicator.vala:448 src/window.vala:240
 msgid "Previous"
 msgstr "Précédent"
 
-#: src/status-indicator.vala:405
+#: src/status-indicator.vala:451
 msgid "Pause"
 msgstr "Pause"
 
-#: src/status-indicator.vala:406
+#: src/status-indicator.vala:452
 msgid "Play"
 msgstr "Lecture"
 
-#: src/status-indicator.vala:408 src/window.vala:259
+#: src/status-indicator.vala:454 src/window.vala:259
 msgid "Next"
 msgstr "Suivant"
 
-#: src/status-indicator.vala:410
+#: src/status-indicator.vala:456
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Volume : %d %%"
 
-#: src/status-indicator.vala:413 src/window.vala:636
+#: src/status-indicator.vala:459 src/window.vala:636
 msgid "Mute"
 msgstr "Couper le son"
 
-#: src/status-indicator.vala:414 src/window.vala:632
+#: src/status-indicator.vala:460 src/window.vala:632
 msgid "Restore volume"
 msgstr "Restaurer le volume"
 
-#: src/status-indicator.vala:424 src/window.vala:136
+#: src/status-indicator.vala:470 src/window.vala:136
 msgid "Compact Mode"
 msgstr "Mode compact"
 
-#: src/status-indicator.vala:426 src/preferences-window.vala:15
+#: src/status-indicator.vala:472 src/preferences-window.vala:15
 #: src/preferences-window.vala:32 src/window.vala:137
 msgid "Preferences"
 msgstr "Préférences"
 
-#: src/status-indicator.vala:428
+#: src/status-indicator.vala:474
 msgid "About"
 msgstr "À propos"
 
-#: src/status-indicator.vala:430 src/window.vala:138
+#: src/status-indicator.vala:476 src/window.vala:138
 msgid "Quit"
 msgstr "Quitter"
 
-#: src/application.vala:334
+#: src/application.vala:373
 msgid "MPRIS MiniPlayer is running in the background"
 msgstr "MPRIS MiniPlayer s’exécute en arrière-plan"
 
-#: src/application.vala:336
+#: src/application.vala:375
 msgid ""
 "The window will appear automatically when a compatible media player becomes "
 "available."
@@ -113,13 +118,13 @@ msgstr ""
 "La fenêtre apparaîtra automatiquement lorsqu’un lecteur multimédia "
 "compatible sera disponible."
 
-#: src/application.vala:338
+#: src/application.vala:377
 msgid "Open the window when you want to control a compatible media player."
 msgstr ""
 "Ouvrez la fenêtre lorsque vous souhaitez contrôler un lecteur multimédia "
 "compatible."
 
-#: src/application.vala:340
+#: src/application.vala:379
 msgid "Open"
 msgstr "Ouvrir"
 
@@ -225,11 +230,11 @@ msgstr "Lancez un lecteur compatible MPRIS"
 msgid "Player unavailable"
 msgstr "Lecteur indisponible"
 
-#: src/mpris-player.vala:268
+#: src/mpris-player.vala:276
 msgid "Unknown track"
 msgstr "Titre inconnu"
 
-#: src/mpris-player.vala:275
+#: src/mpris-player.vala:283
 msgid "Unknown artist"
 msgstr "Artiste inconnu"
 

--- a/po/mpris-miniplayer.pot
+++ b/po/mpris-miniplayer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mpris-miniplayer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-15 10:41+0200\n"
+"POT-Creation-Date: 2026-08-15 11:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.desktop.in:2
 #: data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml.in:6
-#: src/status-indicator.vala:38 src/application.vala:208 src/window.vala:46
+#: src/status-indicator.vala:39 src/application.vala:213 src/window.vala:46
 msgid "MPRIS MiniPlayer"
 msgstr ""
 
@@ -46,79 +46,84 @@ msgstr ""
 msgid "Keep watching for MPRIS-compatible media players"
 msgstr ""
 
-#: src/status-indicator.vala:390
+#: src/status-indicator.vala:434
 msgid "Show"
 msgstr ""
 
-#: src/status-indicator.vala:392
+#: src/status-indicator.vala:436
 msgid "Hide"
 msgstr ""
 
-#: src/status-indicator.vala:400 src/window.vala:288
+#: src/status-indicator.vala:438
+#, c-format
+msgid "Update available: %s"
+msgstr ""
+
+#: src/status-indicator.vala:446 src/window.vala:288
 msgid "No player detected"
 msgstr ""
 
-#: src/status-indicator.vala:402 src/window.vala:240
+#: src/status-indicator.vala:448 src/window.vala:240
 msgid "Previous"
 msgstr ""
 
-#: src/status-indicator.vala:405
+#: src/status-indicator.vala:451
 msgid "Pause"
 msgstr ""
 
-#: src/status-indicator.vala:406
+#: src/status-indicator.vala:452
 msgid "Play"
 msgstr ""
 
-#: src/status-indicator.vala:408 src/window.vala:259
+#: src/status-indicator.vala:454 src/window.vala:259
 msgid "Next"
 msgstr ""
 
-#: src/status-indicator.vala:410
+#: src/status-indicator.vala:456
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: src/status-indicator.vala:413 src/window.vala:636
+#: src/status-indicator.vala:459 src/window.vala:636
 msgid "Mute"
 msgstr ""
 
-#: src/status-indicator.vala:414 src/window.vala:632
+#: src/status-indicator.vala:460 src/window.vala:632
 msgid "Restore volume"
 msgstr ""
 
-#: src/status-indicator.vala:424 src/window.vala:136
+#: src/status-indicator.vala:470 src/window.vala:136
 msgid "Compact Mode"
 msgstr ""
 
-#: src/status-indicator.vala:426 src/preferences-window.vala:15
+#: src/status-indicator.vala:472 src/preferences-window.vala:15
 #: src/preferences-window.vala:32 src/window.vala:137
 msgid "Preferences"
 msgstr ""
 
-#: src/status-indicator.vala:428
+#: src/status-indicator.vala:474
 msgid "About"
 msgstr ""
 
-#: src/status-indicator.vala:430 src/window.vala:138
+#: src/status-indicator.vala:476 src/window.vala:138
 msgid "Quit"
 msgstr ""
 
-#: src/application.vala:334
+#: src/application.vala:373
 msgid "MPRIS MiniPlayer is running in the background"
 msgstr ""
 
-#: src/application.vala:336
+#: src/application.vala:375
 msgid ""
 "The window will appear automatically when a compatible media player becomes "
 "available."
 msgstr ""
 
-#: src/application.vala:338
+#: src/application.vala:377
 msgid "Open the window when you want to control a compatible media player."
 msgstr ""
 
-#: src/application.vala:340
+#: src/application.vala:379
 msgid "Open"
 msgstr ""
 
@@ -222,10 +227,10 @@ msgstr ""
 msgid "Player unavailable"
 msgstr ""
 
-#: src/mpris-player.vala:268
+#: src/mpris-player.vala:276
 msgid "Unknown track"
 msgstr ""
 
-#: src/mpris-player.vala:275
+#: src/mpris-player.vala:283
 msgid "Unknown artist"
 msgstr ""

--- a/rpm/mpris-miniplayer.spec
+++ b/rpm/mpris-miniplayer.spec
@@ -16,6 +16,7 @@ BuildRequires:  pkgconfig(gdk-pixbuf-2.0)
 BuildRequires:  pkgconfig(gio-2.0)
 BuildRequires:  pkgconfig(gtk4)
 BuildRequires:  pkgconfig(libadwaita-1) >= 1.5
+BuildRequires:  pkgconfig(libsoup-3.0)
 BuildRequires:  vala
 
 %description

--- a/src/application.vala
+++ b/src/application.vala
@@ -5,6 +5,7 @@ namespace MprisMiniPlayer {
         private AppSettings app_settings;
         private BackgroundPortal background_portal;
         private StatusIndicator status_indicator;
+        private UpdateChecker? update_checker;
         private MprisManager? manager;
         private Window? main_window;
         private PreferencesWindow? preferences_window;
@@ -12,6 +13,8 @@ namespace MprisMiniPlayer {
         private SimpleAction? compact_mode_action;
         private bool suppress_next_start_on_login_portal_update = false;
         private bool startup_activation_handled = false;
+        private bool update_check_started = false;
+        private string latest_release_url = "";
         private bool held = false;
 
         public Application() {
@@ -35,8 +38,10 @@ namespace MprisMiniPlayer {
             status_indicator = new StatusIndicator();
             status_indicator.activated.connect(() => present_window());
             status_indicator.action_requested.connect(on_status_indicator_action_requested);
+            status_indicator.support_changed.connect(maybe_start_update_check);
             status_indicator.set_compact_mode(app_settings.compact_mode);
             status_indicator.set_enabled(app_settings.show_status_indicator);
+            maybe_start_update_check();
 
             try {
                 manager = new MprisManager();
@@ -233,6 +238,7 @@ namespace MprisMiniPlayer {
 
             if (key == "show-status-indicator") {
                 status_indicator.set_enabled(app_settings.show_status_indicator);
+                maybe_start_update_check();
             }
 
             bool compact_mode = app_settings.compact_mode;
@@ -260,6 +266,9 @@ namespace MprisMiniPlayer {
                     break;
                 case "hide":
                     hide_window();
+                    break;
+                case "open-release":
+                    open_latest_release.begin();
                     break;
                 case "previous":
                     if (manager != null && manager.active_player != null) {
@@ -311,6 +320,36 @@ namespace MprisMiniPlayer {
                 case "quit":
                     quit_app();
                     break;
+            }
+        }
+
+        private void maybe_start_update_check() {
+            if (
+                update_check_started
+                || !app_settings.show_status_indicator
+                || !status_indicator.supported
+            ) {
+                return;
+            }
+
+            update_check_started = true;
+            update_checker = new UpdateChecker();
+            update_checker.update_available.connect((version, release_url) => {
+                latest_release_url = release_url;
+                status_indicator.set_update_available(version);
+            });
+            update_checker.check.begin();
+        }
+
+        private async void open_latest_release() {
+            if (latest_release_url == "") {
+                return;
+            }
+
+            try {
+                yield AppInfo.launch_default_for_uri_async(latest_release_url, null);
+            } catch (Error error) {
+                warning("Unable to open release page: %s", error.message);
             }
         }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -17,6 +17,7 @@ executable(
     'main.vala',
     'app-settings.vala',
     'background-portal.vala',
+    'update-checker.vala',
     'status-indicator.vala',
     'application.vala',
     'preferences-window.vala',
@@ -29,6 +30,7 @@ executable(
     dependency('libadwaita-1', version: '>= 1.5'),
     dependency('gio-2.0'),
     dependency('gdk-pixbuf-2.0'),
+    dependency('libsoup-3.0'),
   ],
   vala_args: [
     '--target-glib=2.66',

--- a/src/mpris-player.vala
+++ b/src/mpris-player.vala
@@ -195,7 +195,15 @@ namespace MprisMiniPlayer {
                 return;
             }
 
-            set_player_volume(double.max(0.0, volume + delta));
+            if (delta > 0.0 && volume >= 1.0) {
+                return;
+            }
+
+            double adjusted_volume = double.max(0.0, volume + delta);
+            if (delta > 0.0) {
+                adjusted_volume = double.min(1.0, adjusted_volume);
+            }
+            set_player_volume(adjusted_volume);
         }
 
         public string display_name() {

--- a/src/status-indicator.vala
+++ b/src/status-indicator.vala
@@ -151,6 +151,7 @@ namespace MprisMiniPlayer {
         private const int QUIT_ID = 6;
         private const int MEDIA_SEPARATOR_ID = 7;
         private const int SETTINGS_SEPARATOR_ID = 8;
+        private const int UPDATE_ID = 9;
         private const int TITLE_ID = 10;
         private const int ARTIST_ID = 11;
         private const int ALBUM_ID = 12;
@@ -171,6 +172,7 @@ namespace MprisMiniPlayer {
         private MprisPlayer? player;
         private ulong player_changed_handler_id = 0;
         private string player_state_signature = "none";
+        private string update_version = "";
 
         public signal void action_requested(string action);
 
@@ -237,6 +239,16 @@ namespace MprisMiniPlayer {
                 player_changed_handler_id = player.changed.connect(on_player_changed);
             }
             player_state_signature = build_player_state_signature();
+            notify_layout_changed();
+        }
+
+        [DBus (visible = false)]
+        public void set_update_available(string version) {
+            if (update_version == version) {
+                return;
+            }
+
+            update_version = version;
             notify_layout_changed();
         }
 
@@ -334,6 +346,9 @@ namespace MprisMiniPlayer {
 
                 children.add_value(new Variant.variant(build_item(SETTINGS_SEPARATOR_ID)));
                 children.add_value(new Variant.variant(build_item(COMPACT_MODE_ID)));
+                if (update_version != "") {
+                    children.add_value(new Variant.variant(build_item(UPDATE_ID)));
+                }
                 children.add_value(new Variant.variant(build_item(PREFERENCES_ID)));
                 children.add_value(new Variant.variant(build_item(ABOUT_ID)));
                 children.add_value(new Variant.variant(build_item(QUIT_ID)));
@@ -384,7 +399,11 @@ namespace MprisMiniPlayer {
             }
 
             properties.add("{sv}", "enabled", new Variant.boolean(is_enabled(id)));
-            properties.add("{sv}", "visible", new Variant.boolean(true));
+            properties.add(
+                "{sv}",
+                "visible",
+                new Variant.boolean(id != UPDATE_ID || update_version != "")
+            );
             properties.add("{sv}", "type", new Variant.string("standard"));
             properties.add("{sv}", "label", new Variant.string(get_label(id)));
             string icon_name = get_icon_name(id);
@@ -415,6 +434,8 @@ namespace MprisMiniPlayer {
                     return _("Show");
                 case HIDE_ID:
                     return _("Hide");
+                case UPDATE_ID:
+                    return _("Update available: %s").printf(update_version);
                 case TITLE_ID:
                     return truncate_label(player != null ? player.title : "", 30);
                 case ARTIST_ID:
@@ -465,6 +486,9 @@ namespace MprisMiniPlayer {
                     break;
                 case HIDE_ID:
                     action_requested("hide");
+                    break;
+                case UPDATE_ID:
+                    action_requested("open-release");
                     break;
                 case PREVIOUS_ID:
                     action_requested("previous");
@@ -553,6 +577,7 @@ namespace MprisMiniPlayer {
                 QUIT_ID,
                 MEDIA_SEPARATOR_ID,
                 SETTINGS_SEPARATOR_ID,
+                UPDATE_ID,
                 TITLE_ID,
                 ARTIST_ID,
                 ALBUM_ID,
@@ -630,6 +655,8 @@ namespace MprisMiniPlayer {
                         : "audio-volume-high-symbolic";
                 case MUTE_ID:
                     return "audio-volume-muted-symbolic";
+                case UPDATE_ID:
+                    return "software-update-available-symbolic";
                 default:
                     return "";
             }
@@ -686,6 +713,7 @@ namespace MprisMiniPlayer {
         private bool enabled = false;
         private bool compact_mode = false;
         private MprisPlayer? player;
+        private string update_version = "";
 
         public bool supported { get; private set; default = false; }
 
@@ -727,6 +755,14 @@ namespace MprisMiniPlayer {
 
             if (menu != null) {
                 menu.set_player(selected_player);
+            }
+        }
+
+        public void set_update_available(string version) {
+            update_version = version;
+
+            if (menu != null) {
+                menu.set_update_available(version);
             }
         }
 
@@ -825,12 +861,13 @@ namespace MprisMiniPlayer {
                     return;
                 }
 
-                action_requested(delta > 0 ? "volume-up" : "volume-down");
+                action_requested(delta > 0 ? "volume-down" : "volume-up");
                 show_volume_icon_feedback();
             });
             menu = new StatusNotifierMenu();
             menu.set_compact_mode(compact_mode);
             menu.set_player(player);
+            menu.set_update_available(update_version);
             menu.action_requested.connect((action) => action_requested(action));
 
             try {

--- a/src/update-checker.vala
+++ b/src/update-checker.vala
@@ -1,0 +1,106 @@
+namespace MprisMiniPlayer {
+    public class UpdateChecker : Object {
+        private const string LATEST_RELEASE_URL =
+            "https://github.com/ChrisLauinger77/mpris-miniplayer/releases/latest";
+        private const string RELEASE_PATH_PREFIX =
+            "/ChrisLauinger77/mpris-miniplayer/releases/tag/";
+
+        private Soup.Session session;
+
+        public signal void update_available(string version, string release_url);
+
+        public UpdateChecker() {
+            session = new Soup.Session();
+            session.timeout = 10;
+            session.user_agent = "MPRIS-MiniPlayer/%s".printf(Config.VERSION);
+        }
+
+        public async void check() {
+            var message = new Soup.Message("HEAD", LATEST_RELEASE_URL);
+
+            try {
+                yield session.send_and_read_async(message, Priority.DEFAULT, null);
+            } catch (Error error) {
+                debug("Unable to check for updates: %s", error.message);
+                return;
+            }
+
+            if (message.get_status() != Soup.Status.OK) {
+                debug("Update check returned HTTP status %u", message.get_status());
+                return;
+            }
+
+            process_release_uri(message.get_uri());
+        }
+
+        internal void process_release_uri(Uri release_uri) {
+            string? host = release_uri.get_host();
+            string path = release_uri.get_path();
+            if (
+                release_uri.get_scheme() != "https"
+                || host != "github.com"
+                || !path.has_prefix(RELEASE_PATH_PREFIX)
+            ) {
+                warning("Ignoring unexpected update URL: %s", release_uri.to_string());
+                return;
+            }
+
+            string tag = path.substring(RELEASE_PATH_PREFIX.length);
+            if (tag == "" || tag.contains("/")) {
+                warning("Ignoring malformed release tag in update URL");
+                return;
+            }
+
+            string version = tag.has_prefix("v") ? tag.substring(1) : tag;
+            if (!is_newer_version(version, Config.VERSION)) {
+                return;
+            }
+
+            update_available(version, release_uri.to_string());
+        }
+
+        public static bool is_newer_version(string candidate, string current) {
+            int[] candidate_parts;
+            int[] current_parts;
+            if (!parse_version(candidate, out candidate_parts)) {
+                return false;
+            }
+            if (!parse_version(current, out current_parts)) {
+                return false;
+            }
+
+            for (int i = 0; i < candidate_parts.length; i++) {
+                if (candidate_parts[i] > current_parts[i]) {
+                    return true;
+                }
+                if (candidate_parts[i] < current_parts[i]) {
+                    return false;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool parse_version(string version, out int[] parts) {
+            string normalized = version.has_prefix("v") ? version.substring(1) : version;
+            string[] fields = normalized.split(".");
+            parts = new int[3];
+            if (fields.length != 3) {
+                parts = {};
+                return false;
+            }
+
+            for (int i = 0; i < fields.length; i++) {
+                string field = fields[i];
+                int value = 0;
+                if (field == "" || !int.try_parse(field, out value) || value < 0) {
+                    parts = {};
+                    return false;
+                }
+                parts[i] = value;
+            }
+
+            return true;
+        }
+    }
+}

--- a/tests/update-checker-test.vala
+++ b/tests/update-checker-test.vala
@@ -1,0 +1,67 @@
+private void assert_newer(string candidate, string current, bool expected) {
+    bool actual = MprisMiniPlayer.UpdateChecker.is_newer_version(candidate, current);
+    assert_true(actual == expected);
+}
+
+private void test_version_comparison() {
+    assert_newer("1.3.9", "1.4.0", false);
+    assert_newer("1.4.0", "1.4.0", false);
+    assert_newer("1.4.1", "1.4.0", true);
+    assert_newer("1.5.0", "1.4.9", true);
+    assert_newer("2.0.0", "1.99.99", true);
+    assert_newer("v1.4.1", "1.4.0", true);
+    assert_newer("1.4", "1.4.0", false);
+    assert_newer("1.4.0-beta", "1.4.0", false);
+    assert_newer("latest", "1.4.0", false);
+}
+
+private void test_release_uri() {
+    var checker = new MprisMiniPlayer.UpdateChecker();
+    string found_version = "";
+    string found_url = "";
+    checker.update_available.connect((version, release_url) => {
+        found_version = version;
+        found_url = release_url;
+    });
+
+    try {
+        checker.process_release_uri(Uri.parse(
+            "https://github.com/ChrisLauinger77/mpris-miniplayer/releases/tag/v1.4.1",
+            UriFlags.NONE
+        ));
+    } catch (Error error) {
+        assert_not_reached();
+    }
+
+    assert_cmpstr(found_version, CompareOperator.EQ, "1.4.1");
+    assert_cmpstr(
+        found_url,
+        CompareOperator.EQ,
+        "https://github.com/ChrisLauinger77/mpris-miniplayer/releases/tag/v1.4.1"
+    );
+}
+
+private void test_current_release_uri() {
+    var checker = new MprisMiniPlayer.UpdateChecker();
+    bool emitted = false;
+    checker.update_available.connect(() => emitted = true);
+
+    try {
+        checker.process_release_uri(Uri.parse(
+            "https://github.com/ChrisLauinger77/mpris-miniplayer/releases/tag/v1.4.0",
+            UriFlags.NONE
+        ));
+    } catch (Error error) {
+        assert_not_reached();
+    }
+
+    assert_false(emitted);
+}
+
+public int main(string[] args) {
+    Test.init(ref args);
+    Test.add_func("/update-checker/version-comparison", test_version_comparison);
+    Test.add_func("/update-checker/release-uri", test_release_uri);
+    Test.add_func("/update-checker/current-release-uri", test_current_release_uri);
+    return Test.run();
+}


### PR DESCRIPTION
## Summary

- correct the status notifier mouse-wheel direction and cap upward adjustment at 100%
- preserve externally amplified MPRIS volume while scrolling down normally
- check GitHub once at startup for a newer stable release and show a notifier menu link when available
- add version-comparison tests, translations, dependency declarations, and documentation

## Why

Notifier scrolling was inverted on the target desktop, and upward scrolling could raise volume beyond 100%. The application also had no in-app indication that a newer release was available.

## User impact

Mouse-wheel volume adjustment now follows the expected direction and stops at 100%. If a player already reports amplified volume, it can still be lowered incrementally. When a newer stable release exists, the notifier menu shows a localized update entry that opens the exact GitHub release page.

## Validation

- `meson compile -C build`
- `meson test -C build --print-errorlogs`
- live D-Bus status notifier scroll check at the 100% boundary
- `msgfmt --check` for all translation catalogs
- no untranslated or fuzzy catalog entries
- `desktop-file-validate`
- `appstreamcli validate --no-net`
- Debian changelog and RPM spec parsing
- GitHub Actions YAML parsing
- `git diff --check`