### PR TITLE
Show fallback icon when artwork is missing

### DIFF
--- a/src/window.vala
+++ b/src/window.vala
@@ -164,8 +164,8 @@ namespace MprisMiniPlayer {
             cover.content_fit = Gtk.ContentFit.COVER;
             cover_stack.add_named(cover, "artwork");
 
-            empty_icon = new Gtk.Image.from_icon_name("multimedia-player-symbolic");
-            empty_icon.pixel_size = 42;
+            empty_icon = new Gtk.Image.from_icon_name("audio-x-generic-symbolic");
+            empty_icon.pixel_size = 96;
             empty_icon.add_css_class("dim-label");
             cover_stack.add_named(empty_icon, "empty");
 
@@ -361,6 +361,11 @@ namespace MprisMiniPlayer {
 
         private void set_artwork(string art_url) {
             if (current_art_url == art_url) {
+                if (art_url == "") {
+                    cover.paintable = null;
+                    cover_stack.visible_child_name = "empty";
+                    clear_album_tint();
+                }
                 return;
             }
 


### PR DESCRIPTION
## Summary

- show a large generic audio icon when the active player provides no artwork
- ensure the fallback stack child is selected when the initial artwork URL is empty

## Why

Streams and other MPRIS sources may not expose `mpris:artUrl`. The artwork tile previously remained visually empty because its initial empty URL matched the cached value, causing the artwork update to return before selecting the fallback child.

## User impact

The normal, non-compact player layout now displays a clearly visible generic media icon instead of a blank artwork tile. Compact mode remains unchanged.

## Validation

- `meson compile -C build`
- `git diff --check`
- visually inspected with an mpv Twitch stream that exposes no artwork
