### PR TITLE
Fix status menu window actions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,20 @@ update_checker_test = executable(
 
 test('update checker version comparison', update_checker_test)
 
+status_menu_test = executable(
+  'status-menu-test',
+  [
+    'src/status-indicator.vala',
+    'src/mpris-player.vala',
+    'tests/status-menu-test.vala',
+  ],
+  dependencies: dependency('gio-2.0'),
+  vala_args: ['--target-glib=2.66'],
+  c_args: ['-DGETTEXT_PACKAGE="@0@"'.format(gettext_package)],
+)
+
+test('status menu window actions', status_menu_test)
+
 gnome.post_install(
   glib_compile_schemas: true,
   gtk_update_icon_cache: true,

--- a/src/application.vala
+++ b/src/application.vala
@@ -185,8 +185,17 @@ namespace MprisMiniPlayer {
             }
 
             main_window.refresh_players();
+            bool restore_suspended_window = restore_minimized
+                && main_window.visible
+                && is_main_window_suspended();
             if (request_activation) {
                 main_window.present();
+            } else if (restore_suspended_window) {
+                // Wayland does not provide an activation token through the
+                // StatusNotifier D-Bus API. Remapping restores a compositor-
+                // minimized surface without producing an activation notification.
+                main_window.set_visible(false);
+                main_window.set_visible(true);
             } else {
                 // A player can appear without user interaction. Requesting focus in
                 // that case is rejected by Wayland compositors and may produce an
@@ -229,17 +238,21 @@ namespace MprisMiniPlayer {
             bool window_shown = main_window != null
                 && main_window.visible
                 && main_window.get_mapped();
-            if (
-                window_shown
-                && main_toplevel != null
-                && (
-                    main_toplevel.get_state() & Gdk.ToplevelState.MINIMIZED
-                ) != 0
-            ) {
+            if (window_shown && is_main_window_suspended()) {
                 window_shown = false;
             }
 
             status_indicator.set_window_shown(window_shown);
+        }
+
+        private bool is_main_window_suspended() {
+            return main_toplevel != null
+                && (
+                    main_toplevel.get_state() & (
+                        Gdk.ToplevelState.MINIMIZED
+                        | Gdk.ToplevelState.SUSPENDED
+                    )
+                ) != 0;
         }
 
         private void hide_window() {

--- a/src/application.vala
+++ b/src/application.vala
@@ -36,7 +36,7 @@ namespace MprisMiniPlayer {
             background_portal.autostart_changed.connect(on_portal_autostart_changed);
             setup_actions();
             status_indicator = new StatusIndicator();
-            status_indicator.activated.connect(() => present_window());
+            status_indicator.activated.connect(() => show_window_from_indicator());
             status_indicator.action_requested.connect(on_status_indicator_action_requested);
             status_indicator.support_changed.connect(maybe_start_update_check);
             status_indicator.set_compact_mode(app_settings.compact_mode);
@@ -156,6 +156,10 @@ namespace MprisMiniPlayer {
             show_window(false);
         }
 
+        private void show_window_from_indicator() {
+            show_window(false);
+        }
+
         private void show_window(bool request_activation) {
             if (main_window == null) {
                 main_window = new Window(
@@ -167,6 +171,11 @@ namespace MprisMiniPlayer {
                 main_window.close_request.connect(() => {
                     hide_window();
                     return true;
+                });
+                main_window.notify["visible"].connect(() => {
+                    status_indicator.set_window_visible(
+                        main_window != null && main_window.visible
+                    );
                 });
             }
 
@@ -262,7 +271,7 @@ namespace MprisMiniPlayer {
         private void on_status_indicator_action_requested(string action) {
             switch (action) {
                 case "show":
-                    present_window();
+                    show_window_from_indicator();
                     break;
                 case "hide":
                     hide_window();

--- a/src/application.vala
+++ b/src/application.vala
@@ -8,6 +8,8 @@ namespace MprisMiniPlayer {
         private UpdateChecker? update_checker;
         private MprisManager? manager;
         private Window? main_window;
+        private Gdk.Toplevel? main_toplevel;
+        private ulong main_toplevel_state_handler_id = 0;
         private PreferencesWindow? preferences_window;
         private Adw.AboutDialog? about_dialog;
         private SimpleAction? compact_mode_action;
@@ -157,10 +159,13 @@ namespace MprisMiniPlayer {
         }
 
         private void show_window_from_indicator() {
-            show_window(false);
+            show_window(false, true);
         }
 
-        private void show_window(bool request_activation) {
+        private void show_window(
+            bool request_activation,
+            bool restore_minimized = false
+        ) {
             if (main_window == null) {
                 main_window = new Window(
                     this,
@@ -172,11 +177,11 @@ namespace MprisMiniPlayer {
                     hide_window();
                     return true;
                 });
-                main_window.notify["visible"].connect(() => {
-                    status_indicator.set_window_visible(
-                        main_window != null && main_window.visible
-                    );
-                });
+                main_window.notify["visible"].connect(sync_status_indicator_window_state);
+                main_window.map.connect(sync_status_indicator_window_state);
+                main_window.unmap.connect(sync_status_indicator_window_state);
+                ((Gtk.Widget) main_window).realize.connect(track_main_toplevel);
+                ((Gtk.Widget) main_window).unrealize.connect(clear_main_toplevel);
             }
 
             main_window.refresh_players();
@@ -187,9 +192,54 @@ namespace MprisMiniPlayer {
                 // that case is rejected by Wayland compositors and may produce an
                 // "app is ready" notification instead of showing the window.
                 main_window.set_visible(true);
+                if (restore_minimized) {
+                    main_window.unminimize();
+                }
             }
             background_portal.leave_background();
             withdraw_notification(BACKGROUND_NOTIFICATION_ID);
+        }
+
+        private void track_main_toplevel() {
+            clear_main_toplevel();
+            if (main_window == null) {
+                return;
+            }
+
+            main_toplevel = main_window.get_surface() as Gdk.Toplevel;
+            if (main_toplevel != null) {
+                main_toplevel_state_handler_id =
+                    main_toplevel.notify["state"].connect(
+                        sync_status_indicator_window_state
+                    );
+            }
+            sync_status_indicator_window_state();
+        }
+
+        private void clear_main_toplevel() {
+            if (main_toplevel != null && main_toplevel_state_handler_id != 0) {
+                SignalHandler.disconnect(main_toplevel, main_toplevel_state_handler_id);
+            }
+            main_toplevel_state_handler_id = 0;
+            main_toplevel = null;
+            sync_status_indicator_window_state();
+        }
+
+        private void sync_status_indicator_window_state() {
+            bool window_shown = main_window != null
+                && main_window.visible
+                && main_window.get_mapped();
+            if (
+                window_shown
+                && main_toplevel != null
+                && (
+                    main_toplevel.get_state() & Gdk.ToplevelState.MINIMIZED
+                ) != 0
+            ) {
+                window_shown = false;
+            }
+
+            status_indicator.set_window_shown(window_shown);
         }
 
         private void hide_window() {

--- a/src/status-indicator.vala
+++ b/src/status-indicator.vala
@@ -169,6 +169,7 @@ namespace MprisMiniPlayer {
 
         private uint revision = 1;
         private bool compact_mode = false;
+        private bool window_visible = false;
         private MprisPlayer? player;
         private ulong player_changed_handler_id = 0;
         private string player_state_signature = "none";
@@ -220,6 +221,16 @@ namespace MprisMiniPlayer {
             }
 
             compact_mode = enabled;
+            notify_layout_changed();
+        }
+
+        [DBus (visible = false)]
+        public void set_window_visible(bool visible) {
+            if (window_visible == visible) {
+                return;
+            }
+
+            window_visible = visible;
             notify_layout_changed();
         }
 
@@ -323,8 +334,9 @@ namespace MprisMiniPlayer {
         private Variant build_layout(int recursion_depth = -1) {
             var children = new VariantBuilder(new VariantType("av"));
             if (recursion_depth != 0) {
-                children.add_value(new Variant.variant(build_item(SHOW_ID)));
-                children.add_value(new Variant.variant(build_item(HIDE_ID)));
+                children.add_value(new Variant.variant(
+                    build_item(window_visible ? HIDE_ID : SHOW_ID)
+                ));
                 children.add_value(new Variant.variant(build_item(MEDIA_SEPARATOR_ID)));
 
                 if (player == null) {
@@ -402,7 +414,7 @@ namespace MprisMiniPlayer {
             properties.add(
                 "{sv}",
                 "visible",
-                new Variant.boolean(id != UPDATE_ID || update_version != "")
+                new Variant.boolean(is_visible(id))
             );
             properties.add("{sv}", "type", new Variant.string("standard"));
             properties.add("{sv}", "label", new Variant.string(get_label(id)));
@@ -611,6 +623,12 @@ namespace MprisMiniPlayer {
         }
 
         private bool is_enabled(int id) {
+            if (id == SHOW_ID) {
+                return !window_visible;
+            }
+            if (id == HIDE_ID) {
+                return window_visible;
+            }
             if (
                 id == TITLE_ID
                 || id == ARTIST_ID
@@ -637,6 +655,16 @@ namespace MprisMiniPlayer {
                 return player != null && player.has_volume && player.can_control;
             }
             return true;
+        }
+
+        private bool is_visible(int id) {
+            if (id == SHOW_ID) {
+                return !window_visible;
+            }
+            if (id == HIDE_ID) {
+                return window_visible;
+            }
+            return id != UPDATE_ID || update_version != "";
         }
 
         private string get_icon_name(int id) {
@@ -712,6 +740,7 @@ namespace MprisMiniPlayer {
         private uint volume_icon_timeout_id = 0;
         private bool enabled = false;
         private bool compact_mode = false;
+        private bool window_visible = false;
         private MprisPlayer? player;
         private string update_version = "";
 
@@ -747,6 +776,14 @@ namespace MprisMiniPlayer {
 
             if (menu != null) {
                 menu.set_compact_mode(enabled);
+            }
+        }
+
+        public void set_window_visible(bool visible) {
+            window_visible = visible;
+
+            if (menu != null) {
+                menu.set_window_visible(visible);
             }
         }
 
@@ -866,6 +903,7 @@ namespace MprisMiniPlayer {
             });
             menu = new StatusNotifierMenu();
             menu.set_compact_mode(compact_mode);
+            menu.set_window_visible(window_visible);
             menu.set_player(player);
             menu.set_update_available(update_version);
             menu.action_requested.connect((action) => action_requested(action));

--- a/src/status-indicator.vala
+++ b/src/status-indicator.vala
@@ -169,7 +169,7 @@ namespace MprisMiniPlayer {
 
         private uint revision = 1;
         private bool compact_mode = false;
-        private bool window_visible = false;
+        private bool window_shown = false;
         private MprisPlayer? player;
         private ulong player_changed_handler_id = 0;
         private string player_state_signature = "none";
@@ -225,12 +225,12 @@ namespace MprisMiniPlayer {
         }
 
         [DBus (visible = false)]
-        public void set_window_visible(bool visible) {
-            if (window_visible == visible) {
+        public void set_window_shown(bool shown) {
+            if (window_shown == shown) {
                 return;
             }
 
-            window_visible = visible;
+            window_shown = shown;
             notify_layout_changed();
         }
 
@@ -335,7 +335,7 @@ namespace MprisMiniPlayer {
             var children = new VariantBuilder(new VariantType("av"));
             if (recursion_depth != 0) {
                 children.add_value(new Variant.variant(
-                    build_item(window_visible ? HIDE_ID : SHOW_ID)
+                    build_item(window_shown ? HIDE_ID : SHOW_ID)
                 ));
                 children.add_value(new Variant.variant(build_item(MEDIA_SEPARATOR_ID)));
 
@@ -624,10 +624,10 @@ namespace MprisMiniPlayer {
 
         private bool is_enabled(int id) {
             if (id == SHOW_ID) {
-                return !window_visible;
+                return !window_shown;
             }
             if (id == HIDE_ID) {
-                return window_visible;
+                return window_shown;
             }
             if (
                 id == TITLE_ID
@@ -659,10 +659,10 @@ namespace MprisMiniPlayer {
 
         private bool is_visible(int id) {
             if (id == SHOW_ID) {
-                return !window_visible;
+                return !window_shown;
             }
             if (id == HIDE_ID) {
-                return window_visible;
+                return window_shown;
             }
             return id != UPDATE_ID || update_version != "";
         }
@@ -740,7 +740,7 @@ namespace MprisMiniPlayer {
         private uint volume_icon_timeout_id = 0;
         private bool enabled = false;
         private bool compact_mode = false;
-        private bool window_visible = false;
+        private bool window_shown = false;
         private MprisPlayer? player;
         private string update_version = "";
 
@@ -779,11 +779,11 @@ namespace MprisMiniPlayer {
             }
         }
 
-        public void set_window_visible(bool visible) {
-            window_visible = visible;
+        public void set_window_shown(bool shown) {
+            window_shown = shown;
 
             if (menu != null) {
-                menu.set_window_visible(visible);
+                menu.set_window_shown(shown);
             }
         }
 
@@ -903,7 +903,7 @@ namespace MprisMiniPlayer {
             });
             menu = new StatusNotifierMenu();
             menu.set_compact_mode(compact_mode);
-            menu.set_window_visible(window_visible);
+            menu.set_window_shown(window_shown);
             menu.set_player(player);
             menu.set_update_available(update_version);
             menu.action_requested.connect((action) => action_requested(action));

--- a/tests/status-menu-test.vala
+++ b/tests/status-menu-test.vala
@@ -51,9 +51,9 @@ private void test_hidden_layout() {
     assert_false(get_boolean_property(menu, HIDE_ID, "enabled"));
 }
 
-private void test_visible_layout() {
+private void test_shown_layout() {
     var menu = new MprisMiniPlayer.StatusNotifierMenu();
-    menu.set_window_visible(true);
+    menu.set_window_shown(true);
 
     uint revision;
     Variant layout = get_root_layout(menu, out revision);
@@ -66,25 +66,25 @@ private void test_visible_layout() {
     assert_true(get_boolean_property(menu, HIDE_ID, "enabled"));
 }
 
-private void test_visibility_revision() {
+private void test_shown_state_revision() {
     var menu = new MprisMiniPlayer.StatusNotifierMenu();
     uint initial_revision;
     get_root_layout(menu, out initial_revision);
 
-    menu.set_window_visible(true);
-    uint visible_revision;
-    get_root_layout(menu, out visible_revision);
-    assert_true(visible_revision > initial_revision);
+    menu.set_window_shown(true);
+    uint shown_revision;
+    get_root_layout(menu, out shown_revision);
+    assert_true(shown_revision > initial_revision);
 
-    menu.set_window_visible(true);
+    menu.set_window_shown(true);
     uint unchanged_revision;
     get_root_layout(menu, out unchanged_revision);
-    assert_true(unchanged_revision == visible_revision);
+    assert_true(unchanged_revision == shown_revision);
 
-    menu.set_window_visible(false);
+    menu.set_window_shown(false);
     uint hidden_revision;
     get_root_layout(menu, out hidden_revision);
-    assert_true(hidden_revision > visible_revision);
+    assert_true(hidden_revision > shown_revision);
 }
 
 private void test_only_current_action_activates() {
@@ -99,7 +99,7 @@ private void test_only_current_action_activates() {
         assert_cmpstr(action, CompareOperator.EQ, "show");
 
         action = "";
-        menu.set_window_visible(true);
+        menu.set_window_shown(true);
         menu.event(SHOW_ID, "clicked", new Variant.string(""), 0);
         assert_cmpstr(action, CompareOperator.EQ, "");
         menu.event(HIDE_ID, "clicked", new Variant.string(""), 0);
@@ -112,8 +112,8 @@ private void test_only_current_action_activates() {
 public int main(string[] args) {
     Test.init(ref args);
     Test.add_func("/status-menu/hidden-layout", test_hidden_layout);
-    Test.add_func("/status-menu/visible-layout", test_visible_layout);
-    Test.add_func("/status-menu/visibility-revision", test_visibility_revision);
+    Test.add_func("/status-menu/shown-layout", test_shown_layout);
+    Test.add_func("/status-menu/shown-state-revision", test_shown_state_revision);
     Test.add_func("/status-menu/current-action", test_only_current_action_activates);
     return Test.run();
 }

--- a/tests/status-menu-test.vala
+++ b/tests/status-menu-test.vala
@@ -1,0 +1,119 @@
+private const int ROOT_ID = 0;
+private const int SHOW_ID = 1;
+private const int HIDE_ID = 2;
+
+private bool layout_contains_id(Variant layout, int expected_id) {
+    Variant children = layout.get_child_value(2);
+    for (size_t i = 0; i < children.n_children(); i++) {
+        Variant item = children.get_child_value(i).get_variant();
+        if (item.get_child_value(0).get_int32() == expected_id) {
+            return true;
+        }
+    }
+    return false;
+}
+
+private Variant get_root_layout(
+    MprisMiniPlayer.StatusNotifierMenu menu,
+    out uint revision
+) {
+    Variant layout = new Variant("(ia{sv}av)", 0, null, null);
+    try {
+        menu.get_layout(ROOT_ID, -1, {}, out revision, out layout);
+    } catch (Error error) {
+        assert_not_reached();
+    }
+    return layout;
+}
+
+private bool get_boolean_property(
+    MprisMiniPlayer.StatusNotifierMenu menu,
+    int id,
+    string name
+) {
+    try {
+        return menu.get_property(id, name).get_boolean();
+    } catch (Error error) {
+        assert_not_reached();
+    }
+}
+
+private void test_hidden_layout() {
+    var menu = new MprisMiniPlayer.StatusNotifierMenu();
+    uint revision;
+    Variant layout = get_root_layout(menu, out revision);
+
+    assert_true(layout_contains_id(layout, SHOW_ID));
+    assert_false(layout_contains_id(layout, HIDE_ID));
+    assert_true(get_boolean_property(menu, SHOW_ID, "visible"));
+    assert_true(get_boolean_property(menu, SHOW_ID, "enabled"));
+    assert_false(get_boolean_property(menu, HIDE_ID, "visible"));
+    assert_false(get_boolean_property(menu, HIDE_ID, "enabled"));
+}
+
+private void test_visible_layout() {
+    var menu = new MprisMiniPlayer.StatusNotifierMenu();
+    menu.set_window_visible(true);
+
+    uint revision;
+    Variant layout = get_root_layout(menu, out revision);
+
+    assert_false(layout_contains_id(layout, SHOW_ID));
+    assert_true(layout_contains_id(layout, HIDE_ID));
+    assert_false(get_boolean_property(menu, SHOW_ID, "visible"));
+    assert_false(get_boolean_property(menu, SHOW_ID, "enabled"));
+    assert_true(get_boolean_property(menu, HIDE_ID, "visible"));
+    assert_true(get_boolean_property(menu, HIDE_ID, "enabled"));
+}
+
+private void test_visibility_revision() {
+    var menu = new MprisMiniPlayer.StatusNotifierMenu();
+    uint initial_revision;
+    get_root_layout(menu, out initial_revision);
+
+    menu.set_window_visible(true);
+    uint visible_revision;
+    get_root_layout(menu, out visible_revision);
+    assert_true(visible_revision > initial_revision);
+
+    menu.set_window_visible(true);
+    uint unchanged_revision;
+    get_root_layout(menu, out unchanged_revision);
+    assert_true(unchanged_revision == visible_revision);
+
+    menu.set_window_visible(false);
+    uint hidden_revision;
+    get_root_layout(menu, out hidden_revision);
+    assert_true(hidden_revision > visible_revision);
+}
+
+private void test_only_current_action_activates() {
+    var menu = new MprisMiniPlayer.StatusNotifierMenu();
+    string action = "";
+    menu.action_requested.connect((requested_action) => action = requested_action);
+
+    try {
+        menu.event(HIDE_ID, "clicked", new Variant.string(""), 0);
+        assert_cmpstr(action, CompareOperator.EQ, "");
+        menu.event(SHOW_ID, "clicked", new Variant.string(""), 0);
+        assert_cmpstr(action, CompareOperator.EQ, "show");
+
+        action = "";
+        menu.set_window_visible(true);
+        menu.event(SHOW_ID, "clicked", new Variant.string(""), 0);
+        assert_cmpstr(action, CompareOperator.EQ, "");
+        menu.event(HIDE_ID, "clicked", new Variant.string(""), 0);
+        assert_cmpstr(action, CompareOperator.EQ, "hide");
+    } catch (Error error) {
+        assert_not_reached();
+    }
+}
+
+public int main(string[] args) {
+    Test.init(ref args);
+    Test.add_func("/status-menu/hidden-layout", test_hidden_layout);
+    Test.add_func("/status-menu/visible-layout", test_visible_layout);
+    Test.add_func("/status-menu/visibility-revision", test_visibility_revision);
+    Test.add_func("/status-menu/current-action", test_only_current_action_activates);
+    return Test.run();
+}


### PR DESCRIPTION
## Summary

- show only the applicable Show or Hide action in the status notifier menu
- track the mini-player's actual visibility and refresh the D-Bus menu when it changes
- map the window without requesting focus for status-indicator actions
- add automated coverage for menu layouts, properties, revisions, and stale actions

## Why

The menu always exposed both Show and Hide. On Wayland, Show called `present()` from a StatusNotifier D-Bus action without an activation token, so GNOME could display an application-ready notification while leaving the hidden mini-player unmapped.

## User impact

A visible mini-player now has only a Hide menu entry, while a hidden mini-player has only Show. Selecting Show or activating the status icon reliably maps the window; the compositor remains responsible for focus and stacking.

## Validation

- `meson compile -C build`
- `meson test -C build --print-errorlogs`
- live D-Bus Hide → Show → Hide menu transition on GNOME
- live status-icon activation from the hidden state
- `desktop-file-validate build/data/io.github.ChrisLauinger.MprisMiniPlayer.desktop`
- `appstreamcli validate --no-net build/data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml`
- `git diff --check`