### PR TITLE
Fix album artwork loading and fallback behavior

### DIFF
--- a/io.github.ChrisLauinger.MprisMiniPlayer.yml
+++ b/io.github.ChrisLauinger.MprisMiniPlayer.yml
@@ -5,6 +5,7 @@ sdk: org.gnome.Sdk
 command: mpris-miniplayer
 finish-args:
   - --share=ipc
+  - --share=network
   - --socket=wayland
   - --socket=fallback-x11
   - --socket=session-bus

--- a/src/window.vala
+++ b/src/window.vala
@@ -411,7 +411,22 @@ namespace MprisMiniPlayer {
                 if (art_url.has_prefix("data:")) {
                     bytes = decode_data_uri(art_url);
                 } else if (art_url.has_prefix("http://") || art_url.has_prefix("https://")) {
-                    var message = new Soup.Message("GET", art_url);
+                    Uri uri = Uri.parse(art_url, UriFlags.NONE);
+                    string scheme = uri.get_scheme().down();
+                    string? host = uri.get_host();
+                    if (
+                        (scheme != "http" && scheme != "https")
+                        || host == null
+                        || host == ""
+                    ) {
+                        throw new IOError.INVALID_ARGUMENT("Artwork HTTP URI is invalid");
+                    }
+
+                    Soup.Message? message = new Soup.Message.from_uri("GET", uri);
+                    if (message == null) {
+                        throw new IOError.INVALID_ARGUMENT("Artwork HTTP URI is invalid");
+                    }
+
                     var stream = yield artwork_session.send_async(
                         message,
                         Priority.DEFAULT,

--- a/src/window.vala
+++ b/src/window.vala
@@ -1,5 +1,9 @@
 namespace MprisMiniPlayer {
     public class Window : Adw.ApplicationWindow {
+        private const int64 MAX_ARTWORK_BYTES = 10 * 1024 * 1024;
+        private const size_t ARTWORK_READ_CHUNK_BYTES = 64 * 1024;
+        private const uint ARTWORK_TIMEOUT_SECONDS = 15;
+
         private MprisManager? manager;
         private MprisPlayer? player;
         private ulong player_changed_handler_id = 0;
@@ -395,13 +399,20 @@ namespace MprisMiniPlayer {
             uint request_id,
             Cancellable cancellable
         ) {
+            uint timeout_id = 0;
+            timeout_id = Timeout.add_seconds(ARTWORK_TIMEOUT_SECONDS, () => {
+                timeout_id = 0;
+                cancellable.cancel();
+                return Source.REMOVE;
+            });
+
             try {
-                Bytes bytes;
+                Bytes bytes = new Bytes(null);
                 if (art_url.has_prefix("data:")) {
                     bytes = decode_data_uri(art_url);
                 } else if (art_url.has_prefix("http://") || art_url.has_prefix("https://")) {
                     var message = new Soup.Message("GET", art_url);
-                    bytes = yield artwork_session.send_and_read_async(
+                    var stream = yield artwork_session.send_async(
                         message,
                         Priority.DEFAULT,
                         cancellable
@@ -409,16 +420,36 @@ namespace MprisMiniPlayer {
 
                     uint status = message.get_status();
                     if (status < 200 || status >= 300) {
+                        close_artwork_stream(stream);
                         throw new IOError.FAILED(
                             "Artwork request returned HTTP status %u".printf(status)
                         );
                     }
+
+                    int64 content_length = message.get_response_headers().get_content_length();
+                    if (content_length > MAX_ARTWORK_BYTES) {
+                        close_artwork_stream(stream);
+                        throw new IOError.MESSAGE_TOO_LARGE(
+                            "Album artwork exceeds the %" + int64.FORMAT + " byte limit",
+                            MAX_ARTWORK_BYTES
+                        );
+                    }
+
+                    try {
+                        bytes = yield read_artwork_stream(stream, cancellable);
+                    } finally {
+                        close_artwork_stream(stream);
+                    }
                 } else {
-                    string? etag;
-                    bytes = yield File.new_for_uri(art_url).load_bytes_async(
-                        cancellable,
-                        out etag
+                    var stream = yield File.new_for_uri(art_url).read_async(
+                        Priority.DEFAULT,
+                        cancellable
                     );
+                    try {
+                        bytes = yield read_artwork_stream(stream, cancellable);
+                    } finally {
+                        close_artwork_stream(stream);
+                    }
                 }
 
                 if (request_id != artwork_request_id || cancellable.is_cancelled()) {
@@ -442,6 +473,51 @@ namespace MprisMiniPlayer {
                     clear_album_tint();
                     debug("Unable to load album artwork: %s", error.message);
                 }
+            } finally {
+                if (timeout_id != 0) {
+                    Source.remove(timeout_id);
+                }
+            }
+        }
+
+        private async Bytes read_artwork_stream(
+            InputStream stream,
+            Cancellable cancellable
+        ) throws Error {
+            var buffer = new MemoryOutputStream.resizable();
+            int64 total_bytes = 0;
+
+            while (true) {
+                Bytes chunk = yield stream.read_bytes_async(
+                    ARTWORK_READ_CHUNK_BYTES,
+                    Priority.DEFAULT,
+                    cancellable
+                );
+                size_t chunk_size = chunk.get_size();
+                if (chunk_size == 0) {
+                    break;
+                }
+
+                total_bytes += (int64) chunk_size;
+                if (total_bytes > MAX_ARTWORK_BYTES) {
+                    throw new IOError.MESSAGE_TOO_LARGE(
+                        "Album artwork exceeds the %" + int64.FORMAT + " byte limit",
+                        MAX_ARTWORK_BYTES
+                    );
+                }
+
+                buffer.write_bytes(chunk, cancellable);
+            }
+
+            buffer.close(cancellable);
+            return buffer.steal_as_bytes();
+        }
+
+        private void close_artwork_stream(InputStream stream) {
+            try {
+                stream.close();
+            } catch (Error error) {
+                debug("Unable to close album artwork stream: %s", error.message);
             }
         }
 
@@ -456,9 +532,23 @@ namespace MprisMiniPlayer {
                 throw new IOError.NOT_SUPPORTED("Artwork data URI is not base64 encoded");
             }
 
-            uint8[] data = Base64.decode(uri.substring(separator + 1));
+            string payload = uri.substring(separator + 1);
+            if ((int64) payload.length > MAX_ARTWORK_BYTES * 4 / 3 + 4) {
+                throw new IOError.MESSAGE_TOO_LARGE(
+                    "Album artwork exceeds the %" + int64.FORMAT + " byte limit",
+                    MAX_ARTWORK_BYTES
+                );
+            }
+
+            uint8[] data = Base64.decode(payload);
             if (data.length == 0) {
                 throw new IOError.INVALID_DATA("Artwork data URI has an empty payload");
+            }
+            if ((int64) data.length > MAX_ARTWORK_BYTES) {
+                throw new IOError.MESSAGE_TOO_LARGE(
+                    "Album artwork exceeds the %" + int64.FORMAT + " byte limit",
+                    MAX_ARTWORK_BYTES
+                );
             }
 
             return new Bytes(data);

--- a/src/window.vala
+++ b/src/window.vala
@@ -1,6 +1,9 @@
 namespace MprisMiniPlayer {
     public class Window : Adw.ApplicationWindow {
         private const int64 MAX_ARTWORK_BYTES = 10 * 1024 * 1024;
+        private const int MAX_ARTWORK_DIMENSION = 8192;
+        private const int64 MAX_ARTWORK_PIXELS = 16 * 1024 * 1024;
+        private const int ARTWORK_DECODE_SIZE = 256;
         private const size_t ARTWORK_READ_CHUNK_BYTES = 64 * 1024;
         private const uint ARTWORK_TIMEOUT_SECONDS = 15;
 
@@ -13,7 +16,7 @@ namespace MprisMiniPlayer {
         private uint artwork_request_id = 0;
         private Soup.Session artwork_session;
         private Cancellable? artwork_cancellable;
-        private Bytes? current_artwork_bytes;
+        private Gdk.Pixbuf? current_artwork_pixbuf;
         private Gtk.CssProvider tint_provider;
 
         private Gtk.Box main_box;
@@ -80,8 +83,8 @@ namespace MprisMiniPlayer {
             album_tint_enabled = enabled;
             if (!enabled) {
                 clear_album_tint();
-            } else if (current_artwork_bytes != null) {
-                apply_album_tint_from_bytes(current_artwork_bytes);
+            } else if (current_artwork_pixbuf != null) {
+                apply_album_tint(current_artwork_pixbuf);
             }
         }
 
@@ -358,7 +361,7 @@ namespace MprisMiniPlayer {
             cover_stack.visible_child_name = "empty";
             cover.paintable = null;
             current_art_url = "";
-            current_artwork_bytes = null;
+            current_artwork_pixbuf = null;
             cancel_artwork_request();
             artwork_request_id++;
             clear_album_tint();
@@ -381,7 +384,7 @@ namespace MprisMiniPlayer {
 
             current_art_url = art_url;
             uint request_id = ++artwork_request_id;
-            current_artwork_bytes = null;
+            current_artwork_pixbuf = null;
             cancel_artwork_request();
             cover.paintable = null;
             cover_stack.visible_child_name = "empty";
@@ -477,18 +480,28 @@ namespace MprisMiniPlayer {
                     return;
                 }
 
-                var texture = Gdk.Texture.from_bytes(bytes);
-                current_artwork_bytes = bytes;
+                Gdk.Pixbuf pixbuf = decode_artwork(bytes);
+                Gdk.MemoryFormat format = pixbuf.get_has_alpha()
+                    ? Gdk.MemoryFormat.R8G8B8A8
+                    : Gdk.MemoryFormat.R8G8B8;
+                var texture = new Gdk.MemoryTexture(
+                    pixbuf.get_width(),
+                    pixbuf.get_height(),
+                    format,
+                    pixbuf.read_pixel_bytes(),
+                    (size_t) pixbuf.get_rowstride()
+                );
+                current_artwork_pixbuf = pixbuf;
                 cover.paintable = texture;
                 cover_stack.visible_child_name = "artwork";
                 artwork_cancellable = null;
                 if (album_tint_enabled) {
-                    apply_album_tint_from_bytes(bytes);
+                    apply_album_tint(pixbuf);
                 }
             } catch (Error error) {
                 if (request_id == artwork_request_id) {
                     artwork_cancellable = null;
-                    current_artwork_bytes = null;
+                    current_artwork_pixbuf = null;
                     cover.paintable = null;
                     cover_stack.visible_child_name = "empty";
                     clear_album_tint();
@@ -575,6 +588,80 @@ namespace MprisMiniPlayer {
             return new Bytes(data);
         }
 
+        private Gdk.Pixbuf decode_artwork(Bytes bytes) throws Error {
+            var loader = new Gdk.PixbufLoader();
+            bool dimensions_ready = false;
+            bool dimensions_valid = false;
+
+            loader.size_prepared.connect((width, height) => {
+                dimensions_ready = true;
+                dimensions_valid = (
+                    width > 0
+                    && height > 0
+                    && width <= MAX_ARTWORK_DIMENSION
+                    && height <= MAX_ARTWORK_DIMENSION
+                    && (int64) width * (int64) height <= MAX_ARTWORK_PIXELS
+                );
+
+                if (!dimensions_valid) {
+                    loader.set_size(1, 1);
+                    return;
+                }
+
+                double scale = double.min(
+                    1.0,
+                    ARTWORK_DECODE_SIZE / (double) int.max(width, height)
+                );
+                loader.set_size(
+                    int.max(1, (int) (width * scale + 0.5)),
+                    int.max(1, (int) (height * scale + 0.5))
+                );
+            });
+
+            loader.write_bytes(bytes);
+            loader.close();
+            if (!dimensions_ready) {
+                throw new IOError.INVALID_DATA("Artwork has no valid dimensions");
+            }
+            if (!dimensions_valid) {
+                throw new IOError.MESSAGE_TOO_LARGE(
+                    "Album artwork dimensions exceed the supported limit"
+                );
+            }
+
+            unowned Gdk.Pixbuf? loaded_pixbuf = loader.get_pixbuf();
+            if (loaded_pixbuf == null) {
+                throw new IOError.INVALID_DATA("Unable to decode album artwork");
+            }
+
+            Gdk.Pixbuf? pixbuf;
+            if (
+                loaded_pixbuf.get_width() > ARTWORK_DECODE_SIZE
+                || loaded_pixbuf.get_height() > ARTWORK_DECODE_SIZE
+            ) {
+                double scale = double.min(
+                    1.0,
+                    ARTWORK_DECODE_SIZE / (double) int.max(
+                        loaded_pixbuf.get_width(),
+                        loaded_pixbuf.get_height()
+                    )
+                );
+                pixbuf = loaded_pixbuf.scale_simple(
+                    int.max(1, (int) (loaded_pixbuf.get_width() * scale + 0.5)),
+                    int.max(1, (int) (loaded_pixbuf.get_height() * scale + 0.5)),
+                    Gdk.InterpType.BILINEAR
+                );
+            } else {
+                pixbuf = loaded_pixbuf.copy();
+            }
+
+            if (pixbuf == null) {
+                throw new IOError.FAILED("Unable to copy decoded album artwork");
+            }
+
+            return pixbuf;
+        }
+
         private void cancel_artwork_request() {
             if (artwork_cancellable == null) {
                 return;
@@ -582,21 +669,6 @@ namespace MprisMiniPlayer {
 
             artwork_cancellable.cancel();
             artwork_cancellable = null;
-        }
-
-        private void apply_album_tint_from_bytes(Bytes bytes) {
-            try {
-                var stream = new MemoryInputStream.from_bytes(bytes);
-                var pixbuf = new Gdk.Pixbuf.from_stream_at_scale(
-                    stream,
-                    32,
-                    32,
-                    true
-                );
-                apply_album_tint(pixbuf);
-            } catch (Error error) {
-                clear_album_tint();
-            }
         }
 
         private void apply_album_tint(Gdk.Pixbuf pixbuf) {

--- a/src/window.vala
+++ b/src/window.vala
@@ -583,7 +583,7 @@ namespace MprisMiniPlayer {
         }
 
         private Gdk.Pixbuf decode_artwork(Bytes bytes) throws Error {
-            reject_animated_artwork(bytes);
+            validate_static_artwork(bytes);
 
             var loader = new Gdk.PixbufLoader();
             bool dimensions_ready = false;
@@ -687,13 +687,26 @@ namespace MprisMiniPlayer {
             );
         }
 
-        private void reject_animated_artwork(Bytes bytes) throws Error {
+        private void validate_static_artwork(Bytes bytes) throws Error {
             int size = (int) bytes.get_size();
             if (
                 artwork_bytes_match(bytes, 0, "GIF87a")
                 || artwork_bytes_match(bytes, 0, "GIF89a")
             ) {
                 throw new IOError.NOT_SUPPORTED("GIF artwork is not supported");
+            }
+
+            if (
+                size >= 3
+                && bytes[0] == 0xff
+                && bytes[1] == 0xd8
+                && bytes[2] == 0xff
+            ) {
+                return;
+            }
+
+            if (size >= 2 && bytes[0] == 'B' && bytes[1] == 'M') {
+                return;
             }
 
             if (
@@ -705,7 +718,7 @@ namespace MprisMiniPlayer {
                 && bytes[6] == 0x1a
                 && bytes[7] == 0x0a
             ) {
-                reject_animated_png(bytes, size);
+                validate_static_png(bytes, size);
                 return;
             }
 
@@ -714,11 +727,14 @@ namespace MprisMiniPlayer {
                 && artwork_bytes_match(bytes, 0, "RIFF")
                 && artwork_bytes_match(bytes, 8, "WEBP")
             ) {
-                reject_animated_webp(bytes, size);
+                validate_static_webp(bytes, size);
+                return;
             }
+
+            throw new IOError.NOT_SUPPORTED("Artwork image format is not supported");
         }
 
-        private void reject_animated_png(Bytes bytes, int size) throws Error {
+        private void validate_static_png(Bytes bytes, int size) throws Error {
             int offset = 8;
             while (offset <= size - 12) {
                 uint32 chunk_length = read_uint32_be(bytes, offset);
@@ -740,7 +756,7 @@ namespace MprisMiniPlayer {
             }
         }
 
-        private void reject_animated_webp(Bytes bytes, int size) throws Error {
+        private void validate_static_webp(Bytes bytes, int size) throws Error {
             int offset = 12;
             while (offset <= size - 8) {
                 uint32 chunk_length = read_uint32_le(bytes, offset + 4);

--- a/src/window.vala
+++ b/src/window.vala
@@ -481,16 +481,7 @@ namespace MprisMiniPlayer {
                 }
 
                 Gdk.Pixbuf pixbuf = decode_artwork(bytes);
-                Gdk.MemoryFormat format = pixbuf.get_has_alpha()
-                    ? Gdk.MemoryFormat.R8G8B8A8
-                    : Gdk.MemoryFormat.R8G8B8;
-                var texture = new Gdk.MemoryTexture(
-                    pixbuf.get_width(),
-                    pixbuf.get_height(),
-                    format,
-                    pixbuf.read_pixel_bytes(),
-                    (size_t) pixbuf.get_rowstride()
-                );
+                var texture = texture_from_pixbuf(pixbuf);
                 current_artwork_pixbuf = pixbuf;
                 cover.paintable = texture;
                 cover_stack.visible_child_name = "artwork";
@@ -662,6 +653,35 @@ namespace MprisMiniPlayer {
             }
 
             return pixbuf;
+        }
+
+        private Gdk.MemoryTexture texture_from_pixbuf(Gdk.Pixbuf pixbuf) {
+            int width = pixbuf.get_width();
+            int height = pixbuf.get_height();
+            int channels = pixbuf.get_n_channels();
+            int source_stride = pixbuf.get_rowstride();
+            int texture_stride = width * channels;
+            uint8[] texture_pixels = new uint8[texture_stride * height];
+            unowned uint8[] source_pixels = pixbuf.get_pixels();
+
+            for (int y = 0; y < height; y++) {
+                int source_offset = y * source_stride;
+                int texture_offset = y * texture_stride;
+                for (int x = 0; x < texture_stride; x++) {
+                    texture_pixels[texture_offset + x] = source_pixels[source_offset + x];
+                }
+            }
+
+            Gdk.MemoryFormat format = pixbuf.get_has_alpha()
+                ? Gdk.MemoryFormat.R8G8B8A8
+                : Gdk.MemoryFormat.R8G8B8;
+            return new Gdk.MemoryTexture(
+                width,
+                height,
+                format,
+                new Bytes.take((owned) texture_pixels),
+                (size_t) texture_stride
+            );
         }
 
         private void reject_animated_artwork(Bytes bytes) throws Error {

--- a/src/window.vala
+++ b/src/window.vala
@@ -444,7 +444,7 @@ namespace MprisMiniPlayer {
 
                     uint status = message.get_status();
                     if (status < 200 || status >= 300) {
-                        close_artwork_stream(stream);
+                        yield close_artwork_stream(stream, cancellable);
                         throw new IOError.FAILED(
                             "Artwork request returned HTTP status %u".printf(status)
                         );
@@ -452,7 +452,7 @@ namespace MprisMiniPlayer {
 
                     int64 content_length = message.get_response_headers().get_content_length();
                     if (content_length > MAX_ARTWORK_BYTES) {
-                        close_artwork_stream(stream);
+                        yield close_artwork_stream(stream, cancellable);
                         throw new IOError.MESSAGE_TOO_LARGE(
                             "Album artwork exceeds the %" + int64.FORMAT + " byte limit",
                             MAX_ARTWORK_BYTES
@@ -462,7 +462,7 @@ namespace MprisMiniPlayer {
                     try {
                         bytes = yield read_artwork_stream(stream, cancellable);
                     } finally {
-                        close_artwork_stream(stream);
+                        yield close_artwork_stream(stream, cancellable);
                     }
                 } else {
                     var stream = yield File.new_for_uri(art_url).read_async(
@@ -472,7 +472,7 @@ namespace MprisMiniPlayer {
                     try {
                         bytes = yield read_artwork_stream(stream, cancellable);
                     } finally {
-                        close_artwork_stream(stream);
+                        yield close_artwork_stream(stream, cancellable);
                     }
                 }
 
@@ -538,9 +538,12 @@ namespace MprisMiniPlayer {
             return buffer.steal_as_bytes();
         }
 
-        private void close_artwork_stream(InputStream stream) {
+        private async void close_artwork_stream(
+            InputStream stream,
+            Cancellable cancellable
+        ) {
             try {
-                stream.close();
+                yield stream.close_async(Priority.DEFAULT, cancellable);
             } catch (Error error) {
                 debug("Unable to close album artwork stream: %s", error.message);
             }

--- a/src/window.vala
+++ b/src/window.vala
@@ -589,6 +589,8 @@ namespace MprisMiniPlayer {
         }
 
         private Gdk.Pixbuf decode_artwork(Bytes bytes) throws Error {
+            reject_animated_artwork(bytes);
+
             var loader = new Gdk.PixbufLoader();
             bool dimensions_ready = false;
             bool dimensions_valid = false;
@@ -660,6 +662,116 @@ namespace MprisMiniPlayer {
             }
 
             return pixbuf;
+        }
+
+        private void reject_animated_artwork(Bytes bytes) throws Error {
+            int size = (int) bytes.get_size();
+            if (
+                artwork_bytes_match(bytes, 0, "GIF87a")
+                || artwork_bytes_match(bytes, 0, "GIF89a")
+            ) {
+                throw new IOError.NOT_SUPPORTED("GIF artwork is not supported");
+            }
+
+            if (
+                size >= 8
+                && bytes[0] == 0x89
+                && artwork_bytes_match(bytes, 1, "PNG")
+                && bytes[4] == 0x0d
+                && bytes[5] == 0x0a
+                && bytes[6] == 0x1a
+                && bytes[7] == 0x0a
+            ) {
+                reject_animated_png(bytes, size);
+                return;
+            }
+
+            if (
+                size >= 12
+                && artwork_bytes_match(bytes, 0, "RIFF")
+                && artwork_bytes_match(bytes, 8, "WEBP")
+            ) {
+                reject_animated_webp(bytes, size);
+            }
+        }
+
+        private void reject_animated_png(Bytes bytes, int size) throws Error {
+            int offset = 8;
+            while (offset <= size - 12) {
+                uint32 chunk_length = read_uint32_be(bytes, offset);
+                if (chunk_length > (uint32) (size - offset - 12)) {
+                    return;
+                }
+
+                if (artwork_bytes_match(bytes, offset + 4, "acTL")) {
+                    throw new IOError.NOT_SUPPORTED("Animated artwork is not supported");
+                }
+                if (
+                    artwork_bytes_match(bytes, offset + 4, "IDAT")
+                    || artwork_bytes_match(bytes, offset + 4, "IEND")
+                ) {
+                    return;
+                }
+
+                offset += 12 + (int) chunk_length;
+            }
+        }
+
+        private void reject_animated_webp(Bytes bytes, int size) throws Error {
+            int offset = 12;
+            while (offset <= size - 8) {
+                uint32 chunk_length = read_uint32_le(bytes, offset + 4);
+                if (chunk_length > (uint32) (size - offset - 8)) {
+                    return;
+                }
+
+                if (
+                    artwork_bytes_match(bytes, offset, "ANIM")
+                    || artwork_bytes_match(bytes, offset, "ANMF")
+                    || (
+                        artwork_bytes_match(bytes, offset, "VP8X")
+                        && chunk_length > 0
+                        && (bytes[offset + 8] & 0x02) != 0
+                    )
+                ) {
+                    throw new IOError.NOT_SUPPORTED("Animated artwork is not supported");
+                }
+
+                int padded_length = (int) chunk_length + ((int) chunk_length & 1);
+                offset += 8 + padded_length;
+            }
+        }
+
+        private bool artwork_bytes_match(Bytes bytes, int offset, string text) {
+            if (offset < 0 || offset + text.length > (int) bytes.get_size()) {
+                return false;
+            }
+
+            for (int index = 0; index < text.length; index++) {
+                if (bytes[offset + index] != (uint8) text[index]) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private uint32 read_uint32_be(Bytes bytes, int offset) {
+            return (
+                ((uint32) bytes[offset] << 24)
+                | ((uint32) bytes[offset + 1] << 16)
+                | ((uint32) bytes[offset + 2] << 8)
+                | bytes[offset + 3]
+            );
+        }
+
+        private uint32 read_uint32_le(Bytes bytes, int offset) {
+            return (
+                bytes[offset]
+                | ((uint32) bytes[offset + 1] << 8)
+                | ((uint32) bytes[offset + 2] << 16)
+                | ((uint32) bytes[offset + 3] << 24)
+            );
         }
 
         private void cancel_artwork_request() {

--- a/src/window.vala
+++ b/src/window.vala
@@ -408,9 +408,15 @@ namespace MprisMiniPlayer {
 
             try {
                 Bytes bytes = new Bytes(null);
-                if (art_url.has_prefix("data:")) {
+                string? parsed_scheme = Uri.parse_scheme(art_url);
+                if (parsed_scheme == null) {
+                    throw new IOError.INVALID_ARGUMENT("Artwork URI has no valid scheme");
+                }
+
+                string normalized_scheme = parsed_scheme.down();
+                if (normalized_scheme == "data") {
                     bytes = decode_data_uri(art_url);
-                } else if (art_url.has_prefix("http://") || art_url.has_prefix("https://")) {
+                } else if (normalized_scheme == "http" || normalized_scheme == "https") {
                     Uri uri = Uri.parse(art_url, UriFlags.NONE);
                     string scheme = uri.get_scheme().down();
                     string? host = uri.get_host();

--- a/src/window.vala
+++ b/src/window.vala
@@ -7,6 +7,9 @@ namespace MprisMiniPlayer {
         private bool album_tint_enabled = false;
         private string current_art_url = "";
         private uint artwork_request_id = 0;
+        private Soup.Session artwork_session;
+        private Cancellable? artwork_cancellable;
+        private Bytes? current_artwork_bytes;
         private Gtk.CssProvider tint_provider;
 
         private Gtk.Box main_box;
@@ -51,6 +54,7 @@ namespace MprisMiniPlayer {
             this.manager = manager;
             this.compact_mode = compact_mode;
             this.album_tint_enabled = album_tint_enabled;
+            artwork_session = new Soup.Session();
 
             tint_provider = new Gtk.CssProvider();
             Gtk.StyleContext.add_provider_for_display(
@@ -72,8 +76,8 @@ namespace MprisMiniPlayer {
             album_tint_enabled = enabled;
             if (!enabled) {
                 clear_album_tint();
-            } else if (current_art_url != "") {
-                load_album_color.begin(current_art_url, artwork_request_id);
+            } else if (current_artwork_bytes != null) {
+                apply_album_tint_from_bytes(current_artwork_bytes);
             }
         }
 
@@ -350,6 +354,8 @@ namespace MprisMiniPlayer {
             cover_stack.visible_child_name = "empty";
             cover.paintable = null;
             current_art_url = "";
+            current_artwork_bytes = null;
+            cancel_artwork_request();
             artwork_request_id++;
             clear_album_tint();
             progress_row.visible = false;
@@ -371,42 +377,114 @@ namespace MprisMiniPlayer {
 
             current_art_url = art_url;
             uint request_id = ++artwork_request_id;
+            current_artwork_bytes = null;
+            cancel_artwork_request();
+            cover.paintable = null;
+            cover_stack.visible_child_name = "empty";
+            clear_album_tint();
             if (art_url == "") {
-                cover.paintable = null;
-                cover_stack.visible_child_name = "empty";
-                clear_album_tint();
                 return;
             }
 
-            var file = File.new_for_uri(art_url);
-            cover.set_file(file);
-            cover_stack.visible_child_name = "artwork";
-            if (album_tint_enabled) {
-                load_album_color.begin(art_url, request_id);
+            artwork_cancellable = new Cancellable();
+            load_artwork.begin(art_url, request_id, artwork_cancellable);
+        }
+
+        private async void load_artwork(
+            string art_url,
+            uint request_id,
+            Cancellable cancellable
+        ) {
+            try {
+                Bytes bytes;
+                if (art_url.has_prefix("data:")) {
+                    bytes = decode_data_uri(art_url);
+                } else if (art_url.has_prefix("http://") || art_url.has_prefix("https://")) {
+                    var message = new Soup.Message("GET", art_url);
+                    bytes = yield artwork_session.send_and_read_async(
+                        message,
+                        Priority.DEFAULT,
+                        cancellable
+                    );
+
+                    uint status = message.get_status();
+                    if (status < 200 || status >= 300) {
+                        throw new IOError.FAILED(
+                            "Artwork request returned HTTP status %u".printf(status)
+                        );
+                    }
+                } else {
+                    string? etag;
+                    bytes = yield File.new_for_uri(art_url).load_bytes_async(
+                        cancellable,
+                        out etag
+                    );
+                }
+
+                if (request_id != artwork_request_id || cancellable.is_cancelled()) {
+                    return;
+                }
+
+                var texture = Gdk.Texture.from_bytes(bytes);
+                current_artwork_bytes = bytes;
+                cover.paintable = texture;
+                cover_stack.visible_child_name = "artwork";
+                artwork_cancellable = null;
+                if (album_tint_enabled) {
+                    apply_album_tint_from_bytes(bytes);
+                }
+            } catch (Error error) {
+                if (request_id == artwork_request_id) {
+                    artwork_cancellable = null;
+                    current_artwork_bytes = null;
+                    cover.paintable = null;
+                    cover_stack.visible_child_name = "empty";
+                    clear_album_tint();
+                    debug("Unable to load album artwork: %s", error.message);
+                }
             }
         }
 
-        private async void load_album_color(string art_url, uint request_id) {
+        private Bytes decode_data_uri(string uri) throws Error {
+            int separator = uri.index_of_char(',');
+            if (separator < 0) {
+                throw new IOError.INVALID_ARGUMENT("Artwork data URI has no payload");
+            }
+
+            string media_type = uri.substring(5, separator - 5);
+            if (!media_type.down().has_suffix(";base64")) {
+                throw new IOError.NOT_SUPPORTED("Artwork data URI is not base64 encoded");
+            }
+
+            uint8[] data = Base64.decode(uri.substring(separator + 1));
+            if (data.length == 0) {
+                throw new IOError.INVALID_DATA("Artwork data URI has an empty payload");
+            }
+
+            return new Bytes(data);
+        }
+
+        private void cancel_artwork_request() {
+            if (artwork_cancellable == null) {
+                return;
+            }
+
+            artwork_cancellable.cancel();
+            artwork_cancellable = null;
+        }
+
+        private void apply_album_tint_from_bytes(Bytes bytes) {
             try {
-                var file = File.new_for_uri(art_url);
-                var stream = yield file.read_async();
-                var pixbuf = yield new Gdk.Pixbuf.from_stream_at_scale_async(
+                var stream = new MemoryInputStream.from_bytes(bytes);
+                var pixbuf = new Gdk.Pixbuf.from_stream_at_scale(
                     stream,
                     32,
                     32,
                     true
                 );
-                yield stream.close_async();
-
-                if (!album_tint_enabled || request_id != artwork_request_id) {
-                    return;
-                }
-
                 apply_album_tint(pixbuf);
             } catch (Error error) {
-                if (request_id == artwork_request_id) {
-                    clear_album_tint();
-                }
+                clear_album_tint();
             }
         }
 
@@ -655,5 +733,6 @@ namespace MprisMiniPlayer {
 
             return "%d:%02d".printf(minutes, seconds);
         }
+
     }
 }


### PR DESCRIPTION
## Summary

- load HTTP and HTTPS artwork explicitly through libsoup
- support base64-encoded data URI artwork and retain local URI support
- keep the fallback icon visible until artwork has decoded successfully
- cancel stale requests and reuse loaded bytes for album tinting
- allow network access in the Flatpak manifest

## Validation

- meson compile -C build
- meson test -C build --print-errorlogs
- desktop-file-validate build/data/io.github.ChrisLauinger.MprisMiniPlayer.desktop
- appstreamcli validate --no-net build/data/io.github.ChrisLauinger.MprisMiniPlayer.metainfo.xml
- git diff --check
- live Jellyfin test confirmed the fallback icon replaces the blank artwork card